### PR TITLE
App crash due to initial live location component update.

### DIFF
--- a/app/src/main/java/com/aws/amazonlocation/utils/MapHelper.kt
+++ b/app/src/main/java/com/aws/amazonlocation/utils/MapHelper.kt
@@ -136,7 +136,6 @@ class MapHelper(private val appContext: Context) {
         mLocationEngine?.getLastLocation(locationListener)
 
         if (setCurrentLocation) {
-//            mLocationEngine?.requestLocationUpdates(request, initialLocationListener, Looper.getMainLooper())
             mLocationEngine?.getLastLocation(initialLocationListener)
         } else {
             mLocationEngine?.requestLocationUpdates(
@@ -232,7 +231,6 @@ class MapHelper(private val appContext: Context) {
 
     private val initialLocationListener = object : LocationEngineCallback<LocationEngineResult> {
         override fun onSuccess(result: LocationEngineResult?) {
-            println("Iniitial Location: Success")
             mMapboxMap?.moveCamera(
                 CameraUpdateFactory.newCameraPosition(
                     CameraPosition.Builder().zoom(DEFAULT_CAMERA_ZOOM).padding(
@@ -250,11 +248,13 @@ class MapHelper(private val appContext: Context) {
                     ).build()
                 )
             )
-            mMapboxMap?.locationComponent?.forceLocationUpdate(result?.lastLocation)
+            try{
+                mMapboxMap?.locationComponent?.forceLocationUpdate(result?.lastLocation)
+            }
+            catch (_:Exception){}
         }
 
         override fun onFailure(exception: Exception) {
-            println("Iniitial Location: Failure")
         }
     }
 


### PR DESCRIPTION
Description of changes:
fix(Live Location Component): App crash due to force update live location marker.

The app crashed when it was opened after clearing the application data. This happened because of trying to force update the live location marker initially before the location component got enabled.

App flow for which crashed was logged:
Install application > Accept all location permissions and wait for map to load > close app > clear application data > Restart Application > Application will crash on the above point.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
