### PR TITLE
Modify unauth role to restrict identity pool.

### DIFF
--- a/extra/default-unauth-resources-template.yaml
+++ b/extra/default-unauth-resources-template.yaml
@@ -15,6 +15,8 @@ Resources:
         Statement:
           - Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
+              "StringEquals":
+                "cognito-identity.amazonaws.com:aud": !Ref CognitoIdentityPool
               "ForAnyValue:StringLike":
                 "cognito-identity.amazonaws.com:amr": unauthenticated
             Effect: Allow

--- a/extra/main-cf-template.yaml
+++ b/extra/main-cf-template.yaml
@@ -94,6 +94,8 @@ Resources:
         Statement:
           - Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
+              "StringEquals":
+                "cognito-identity.amazonaws.com:aud": !Ref AmazonLocationDemoCognitoIdentityPool
               "ForAnyValue:StringLike":
                 "cognito-identity.amazonaws.com:amr": unauthenticated
             Effect: Allow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Automated checks flagged the Unauth roles for not specifying the specific identity pool associated with the role. This adds the identity pool check. The resulting behavior should effectively be identical, but it now checks that credentials are issued to users of the intended Cognito Identity Pool.

Tested by submitting the changed yaml files manually to CloudFormation. Results as follows (ids redacted):
```
Default-unauth-resources-template.yaml:

{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "cognito-identity.amazonaws.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "cognito-identity.amazonaws.com:aud": "us-east-1:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx”
                },
                "ForAnyValue:StringLike": {
                    "cognito-identity.amazonaws.com:amr": "unauthenticated"
                }
            }
        }
    ]
}

Main-cf-template.yaml:
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "cognito-identity.amazonaws.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "cognito-identity.amazonaws.com:aud": "us-east-1:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx"
                },
                "ForAnyValue:StringLike": {
                    "cognito-identity.amazonaws.com:amr": "unauthenticated"
                }
            }
        }
    ]
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
