### PR TITLE
Add update and delete policy.

### DIFF
--- a/extra/default-unauth-resources-template.yaml
+++ b/extra/default-unauth-resources-template.yaml
@@ -290,6 +290,8 @@ Resources:
   AmazonLocationDemoKinesisStream:
     Condition: EnablePinTranslate
     Type: AWS::Kinesis::Stream
+    DeletionPolicy: RetainExceptOnCreate
+    UpdateReplacePolicy: Retain
     Properties:
       Name: location.aws.com.demo.app
       RetentionPeriodHours: 24


### PR DESCRIPTION
*Description of changes:*
Fixes a warning flagged by AWS Rules that stateful resources need an explicit update and delete policy.

This has been tested by manually deploying and deleting the cloudformation stack both before and after the change. Prior to the change, deleting the stack would automatically delete the kinesis stream. After the change, deleting the stack retains the kinesis stream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
