### PR TITLE
Fix release build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,11 +80,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     buildFeatures {
         viewBinding = true

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -60,6 +60,11 @@
 #Gson
 -keep class com.google.gson.stream.** { *; }
 
+# AWS IoT MQTT Manager
+-keep class org.eclipse.paho.clent.mqttv3.** {*;}
+-keep class org.eclipse.paho.client.mqttv3.*$* { *; }
+-keep class org.eclipse.paho.client.mqttv3.logging.JSR47Logger { *; }
+
 # Keep class names of Hilt injected ViewModels since their name are used as a multibinding map key.
 -keepnames @dagger.hilt.android.lifecycle.HiltViewModel class * extends androidx.lifecycle.ViewModel
 


### PR DESCRIPTION
*Description of changes:*
This fixes a crash in release builds during simulation mode that occurred due to MQTT failing to find a logging class. The modifications to the proguard rules below fix the crash.

This also changes more java versions to JDK 17.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
