### PR TITLE
Fix back button crash on API 32.

### DIFF
--- a/app/src/main/java/com/aws/amazonlocation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/aws/amazonlocation/ui/main/MainActivity.kt
@@ -245,12 +245,12 @@ class MainActivity : BaseActivity(), CrashListener {
             onBackInvokedDispatcher.registerOnBackInvokedCallback(
                 android.window.OnBackInvokedDispatcher.PRIORITY_DEFAULT
             ) {
-                this.handleOnBackPressed()
+                handleOnBackPressedEvent()
             }
         }
         else {
             onBackPressedDispatcher.addCallback(this /* lifecycle owner */) {
-                this.handleOnBackPressed()
+                handleOnBackPressedEvent()
             }
         }
     }
@@ -893,7 +893,7 @@ class MainActivity : BaseActivity(), CrashListener {
         }
     }
 
-    private fun handleOnBackPressed() {
+    private fun handleOnBackPressedEvent() {
         if (mNavController.currentDestination?.label == AWS_CLOUD_INFORMATION_FRAGMENT) {
             mNavController.popBackStack()
         } else if (mNavController.currentDestination?.label == VERSION_FRAGMENT) {


### PR DESCRIPTION
*Description of changes:*

Due to an ambiguity with "this", the back button callback would crash on APIs < 34. Fixed the ambiguity by renaming the method that needs to be called and removing the "this".

Tested on API32 and API34 and verified that it no longer crashes when the back button is pressed on the main screen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
