### PR TITLE
Updated to use upload-artifact/v4

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -19,8 +19,8 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: amazon-location-services-builds
-          SLACK_COLOR: '#FFFF00'
-          SLACK_ICON_EMOJI: ':hammer:'
+          SLACK_COLOR: "#FFFF00"
+          SLACK_ICON_EMOJI: ":hammer:"
           SLACK_LINK_NAMES: true
           SLACK_TITLE: ${{ format('Android Build №{0} started...', env.BUILD_NUM) }}
           SLACK_MESSAGE: |
@@ -85,7 +85,7 @@ jobs:
             ./gradlew app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.aws.amazonlocation.ui.main.ConnectToAWSTest
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results
@@ -123,9 +123,7 @@ jobs:
             aab_path:./app/build/outputs/bundle/release/app-release.aab
   slackNotification:
     name: slack
-    needs: [
-      build-android
-    ]
+    needs: [build-android]
     if: always()
     runs-on: ubuntu-latest
     env:
@@ -142,7 +140,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: amazon-location-services-builds
           SLACK_COLOR: ${{ env.SUCCESS == 'true' && 'success' || 'failure' }}
-          SLACK_ICON_EMOJI: ':tophat:'
+          SLACK_ICON_EMOJI: ":tophat:"
           SLACK_LINK_NAMES: true
           SLACK_TITLE: ${{ format('Android build №{0} {1}', env.BUILD_NUM, env.SUCCESS == 'true' && 'finished successfully :tada:' || 'failed!') }}
           SLACK_MESSAGE: |

--- a/.github/workflows/test-android-e2e.yml
+++ b/.github/workflows/test-android-e2e.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
 
       - name: Run Unit Tests
         run: |
@@ -67,7 +67,7 @@ jobs:
             ./gradlew app:connectedDebugAndroidTest -i -Pandroid.testInstrumentationRunnerArguments.class=com.aws.amazonlocation.ui.main.ConnectToAWSTest
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -2,7 +2,7 @@ name: Run Unit Tests for Android
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ develop, main ]
+    branches: [develop, main]
 jobs:
   test-android:
     name: Test Android
@@ -30,15 +30,15 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
 
       - name: Run Unit Tests
         run: |
           ./gradlew testDebugUnitTest
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results


### PR DESCRIPTION
## Description
Updated to `upload-artifact/v4` because `v2` has now been EOL'd and no longer works:

https://github.com/aws-geospatial/amazon-location-features-demo-android/actions/runs/10902193719/job/30253548569?pr=81
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Some minor formatting changes were done as well by our auto-format.

This is blocking https://github.com/aws-geospatial/amazon-location-features-demo-android/pull/81 which will address the 2 current security vulnerabilities.