### PR TITLE
ALS-1927 Optimize all E2E test case

### DIFF
--- a/app/src/androidTest/java/com/aws/amazonlocation/GeneralUtils.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/GeneralUtils.kt
@@ -3,13 +3,16 @@ package com.aws.amazonlocation
 import android.content.Context
 import android.provider.Settings
 import android.view.View
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.ViewInteraction
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
+import androidx.test.uiautomator.Until
 import org.hamcrest.Matcher
 import org.junit.Assert
 import java.util.Calendar
@@ -37,6 +40,21 @@ fun enableGPS(context: Context) {
             } while (allowGpsBtn.exists())
         }
     }
+}
+
+fun checkLocationPermission(uiDevice: UiDevice) {
+    val btnContinueToApp =
+        uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/btn_continue_to_app"))
+    if (btnContinueToApp.exists()) {
+        btnContinueToApp.click()
+    }
+    Thread.sleep(DELAY_1000)
+    uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
+    uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
+    uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
+    uiDevice.findObject(By.text(ALLOW))?.click()
+    enableGPS(ApplicationProvider.getApplicationContext())
+    uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
 }
 
 @Suppress("DEPRECATION")
@@ -85,15 +103,6 @@ val mockLocationsExit = listOf(
     MockLocation(23.012348, 72.522382),
     MockLocation(23.011594, 72.522444),
 )
-
-fun failTest(lineNo: Int, exception: Exception?) {
-//    Assert.fail("$TEST_FAILED - Exception caught at line $lineNo: ${exception?.stackTraceToString() ?: "Custom error"}")
-    if (exception != null) {
-        throw exception
-    } else {
-        throw Exception("$TEST_FAILED - Exception caught at line $lineNo: Custom error")
-    }
-}
 
 fun waitUntil(waitTime: Long, maxCount: Int, condition: () -> Boolean?) {
     var count = 0

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/AfterSearchDirectionButtonWorkingTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/AfterSearchDirectionButtonWorkingTest.kt
@@ -18,10 +18,10 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
+import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_DIRECTION_CARD
 import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_FAILED_SEARCH_FIELD_NOT_VISIBLE
@@ -29,7 +29,6 @@ import com.aws.amazonlocation.TEST_FAILED_SEARCH_SHEET
 import com.aws.amazonlocation.TEST_WORD_RIO_TINTO
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.textfield.TextInputEditText
@@ -49,7 +48,6 @@ class AfterSearchDirectionButtonWorkingTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(matches(isDisplayed()))
@@ -60,7 +58,6 @@ class AfterSearchDirectionButtonWorkingTest : BaseTestMainActivity() {
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion")),
                 DELAY_20000,
             )
-            Thread.sleep(DELAY_2000)
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
@@ -100,7 +97,7 @@ class AfterSearchDirectionButtonWorkingTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(118, e)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/AnalyticsTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/AnalyticsTest.kt
@@ -19,17 +19,14 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_ADDRESS
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_MESSAGE_FOUND
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.utils.EventType
 import com.aws.amazonlocation.utils.KEY_MAP_NAME
 import com.aws.amazonlocation.utils.KEY_MAP_STYLE_NAME
@@ -44,7 +41,6 @@ import org.junit.Test
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class AnalyticsTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     private lateinit var preferenceManager: PreferenceManager
@@ -66,17 +62,17 @@ class AnalyticsTest : BaseTestMainActivity() {
     fun checkAnalyticsContent() {
         try {
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
             uiDevice.wait(
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/edt_search_places")),
-                DELAY_5000
+                DELAY_5000,
             )
             // Start - Search event check
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
             edtSearch.perform(click())
             onView(withId(R.id.edt_search_places)).perform(ViewActions.replaceText(TEST_ADDRESS))
-            var snackBarMsg = uiDevice.wait(Until.hasObject(By.text(EventType.PLACE_SEARCH)), DELAY_10000)
+            var snackBarMsg =
+                uiDevice.wait(Until.hasObject(By.text(EventType.PLACE_SEARCH)), DELAY_10000)
             Assert.assertTrue(TEST_FAILED_NO_MESSAGE_FOUND, snackBarMsg)
             edtSearch.perform(ViewActions.closeSoftKeyboard())
             val clSearchSheet =
@@ -84,44 +80,43 @@ class AnalyticsTest : BaseTestMainActivity() {
             val mBottomSheetSearchPlaces: BottomSheetBehavior<ConstraintLayout> =
                 BottomSheetBehavior.from(clSearchSheet)
             mBottomSheetSearchPlaces.state = BottomSheetBehavior.STATE_COLLAPSED
-            uiDevice.wait(Until.hasObject(By.text(mActivityRule.activity.getString(R.string.menu_explore))), DELAY_5000)
-            // End - Search event check
-            Thread.sleep(DELAY_1000)
-            // Start - Screen change event test
+            uiDevice.wait(
+                Until.hasObject(By.text(mActivityRule.activity.getString(R.string.menu_explore))),
+                DELAY_5000,
+            )
             val settingTabText = mActivityRule.activity.getString(R.string.menu_setting)
             onView(
                 allOf(
                     withText(settingTabText),
                     isDescendantOfA(withId(R.id.bottom_navigation_main)),
-                    isDisplayed()
-                )
+                    isDisplayed(),
+                ),
             ).perform(click())
-            snackBarMsg = uiDevice.wait(Until.hasObject(By.text(EventType.SCREEN_OPEN)), DELAY_10000)
+            snackBarMsg =
+                uiDevice.wait(Until.hasObject(By.text(EventType.SCREEN_OPEN)), DELAY_10000)
             Assert.assertTrue(TEST_FAILED_NO_MESSAGE_FOUND, snackBarMsg)
             // End - Screen change event test
             // Start - Map unit change event test
             onView(
                 allOf(
                     withId(R.id.cl_unit_system),
-                    isDisplayed()
-                )
+                    isDisplayed(),
+                ),
             ).perform(click())
 
-            Thread.sleep(DELAY_2000)
             onView(
                 allOf(
                     withId(R.id.ll_imperial),
-                    isDisplayed()
-                )
+                    isDisplayed(),
+                ),
             ).perform(click())
-            Thread.sleep(DELAY_2000)
 
-            snackBarMsg = uiDevice.wait(Until.hasObject(By.text(EventType.MAP_UNIT_CHANGE)), DELAY_10000)
+            snackBarMsg =
+                uiDevice.wait(Until.hasObject(By.text(EventType.MAP_UNIT_CHANGE)), DELAY_10000)
             Assert.assertTrue(TEST_FAILED_NO_MESSAGE_FOUND, snackBarMsg)
             // End - Map unit change event test
         } catch (e: Exception) {
-            failTest(95, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckGoButtonClickLiveNavigationTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckGoButtonClickLiveNavigationTest.kt
@@ -1,29 +1,26 @@
 package com.aws.amazonlocation.ui.main
 
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.GO
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_WORD_SHYAMAL_CROSS_ROAD
+import com.aws.amazonlocation.checkLocationPermission
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
@@ -40,30 +37,21 @@ class CheckGoButtonClickLiveNavigationTest : BaseTestMainActivity() {
     @Test
     fun showGoButtonClickLiveNavigationTest() {
         try {
-            enableGPS(ApplicationProvider.getApplicationContext())
-            uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
+            checkLocationPermission(uiDevice)
 
             val cardDirectionTest =
                 onView(withId(R.id.card_direction)).check(matches(isDisplayed()))
             cardDirectionTest.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val sourceEdt = waitForView(allOf(withId(R.id.edt_search_direction), isDisplayed()))
             sourceEdt?.perform(click())
-
-            Thread.sleep(DELAY_2000)
 
             val clMyLocation =
                 waitForView(allOf(withText(R.string.label_my_location), isDisplayed()))
             clMyLocation?.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val destinationEdt = waitForView(allOf(withId(R.id.edt_search_dest), isDisplayed()))
             destinationEdt?.perform(click(), replaceText(TEST_WORD_SHYAMAL_CROSS_ROAD))
-
-            Thread.sleep(DELAY_2000)
 
             val suggestionListRv = waitForView(
                 allOf(
@@ -92,16 +80,14 @@ class CheckGoButtonClickLiveNavigationTest : BaseTestMainActivity() {
 
             Espresso.closeSoftKeyboard()
 
-            // navListView
             waitForView(allOf(withId(R.id.rv_navigation_list), isDisplayed(), hasMinimumChildCount(1)))
 
             // btnExit
             waitForView(allOf(withId(R.id.btn_exit), isDisplayed())) {
-                failTest(109, null)
+                Assert.fail("$TEST_FAILED button exit not visible")
             }
         } catch (e: Exception) {
-            failTest(145, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckRouteEstimatedTimeAndDistanceTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckRouteEstimatedTimeAndDistanceTest.kt
@@ -8,21 +8,23 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_DISTANCE_OR_TIME_EMPTY
-import com.aws.amazonlocation.TEST_WORD_KEWDALE_PERTH
 import com.aws.amazonlocation.TEST_WORD_CLOVERDALE_PERTH
+import com.aws.amazonlocation.TEST_WORD_KEWDALE_PERTH
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
 import com.aws.amazonlocation.waitForView
@@ -43,18 +45,13 @@ class CheckRouteEstimatedTimeAndDistanceTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val cardDirectionTest =
                 onView(withId(R.id.card_direction)).check(matches(isDisplayed()))
             cardDirectionTest.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val sourceEdt = waitForView(CoreMatchers.allOf(withId(R.id.edt_search_direction), isDisplayed()))
             sourceEdt?.perform(click(), replaceText(TEST_WORD_CLOVERDALE_PERTH))
-
-            Thread.sleep(DELAY_2000)
 
             val suggestionListRvSrc = waitForView(
                 CoreMatchers.allOf(
@@ -70,8 +67,6 @@ class CheckRouteEstimatedTimeAndDistanceTest : BaseTestMainActivity() {
                 ),
             )
 
-            Thread.sleep(DELAY_2000)
-
             val destinationEdt = waitForView(
                 CoreMatchers.allOf(
                     withId(R.id.edt_search_dest),
@@ -79,8 +74,6 @@ class CheckRouteEstimatedTimeAndDistanceTest : BaseTestMainActivity() {
                 ),
             )
             destinationEdt?.perform(click(), replaceText(TEST_WORD_KEWDALE_PERTH))
-
-            Thread.sleep(DELAY_2000)
 
             val suggestionListRvDest = waitForView(
                 CoreMatchers.allOf(
@@ -120,8 +113,6 @@ class CheckRouteEstimatedTimeAndDistanceTest : BaseTestMainActivity() {
                 ),
             )
 
-            Thread.sleep(DELAY_10000)
-
             val tvDriveDistance =
                 mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_drive_distance)
             val tvDriveMinute =
@@ -141,99 +132,8 @@ class CheckRouteEstimatedTimeAndDistanceTest : BaseTestMainActivity() {
                     tvWalkDistance.text.toString().isNotEmpty() && tvWalkMinute.text.toString().isNotEmpty() &&
                     tvTruckDistance.text.toString().isNotEmpty() && tvTruckMinute.text.toString().isNotEmpty(),
             )
-
-//            val cardDirection =
-//                mActivityRule.activity.findViewById<MaterialCardView>(R.id.card_direction)
-//            if (cardDirection.visibility == View.VISIBLE) {
-//                val cardDirectionTest =
-//                    onView(withId(R.id.card_direction)).check(matches(isDisplayed()))
-//                cardDirectionTest.perform(click())
-//                uiDevice.wait(
-//                    Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/edt_search_direction")),
-//                    DELAY_5000,
-//                )
-//                val edtSearchDirection =
-//                    mActivityRule.activity.findViewById<TextInputEditText>(R.id.edt_search_direction)
-//                if (edtSearchDirection.visibility == View.VISIBLE) {
-//                    onView(withId(R.id.edt_search_direction)).perform(ViewActions.typeText(TEST_WORD_9))
-//                    Thread.sleep(DELAY_2000)
-//                    uiDevice.wait(
-//                        Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion_direction")),
-//                        DELAY_20000,
-//                    )
-//                    val rvSearchPlacesSuggestionDirection =
-//                        mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion_direction)
-//                    rvSearchPlacesSuggestionDirection.adapter?.itemCount?.let {
-//                        if (it > 0) {
-//                            onView(withId(R.id.rv_search_places_suggestion_direction)).perform(
-//                                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
-//                                    0,
-//                                    click(),
-//                                ),
-//                            )
-//                        }
-//                    }
-//                    onView(withId(R.id.edt_search_dest)).perform(ViewActions.typeText(TEST_WORD_10))
-//                    Thread.sleep(DELAY_2000)
-//                    uiDevice.wait(
-//                        Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion_direction")),
-//                        DELAY_20000,
-//                    )
-//                    rvSearchPlacesSuggestionDirection.adapter?.itemCount?.let {
-//                        if (it > 0) {
-//                            onView(withId(R.id.rv_search_places_suggestion_direction)).perform(
-//                                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
-//                                    0,
-//                                    click(),
-//                                ),
-//                            )
-//                        }
-//                    }
-//                    uiDevice.wait(
-//                        Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/card_drive_go")),
-//                        DELAY_20000,
-//                    )
-//                    uiDevice.wait(
-//                        Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/card_walk_go")),
-//                        DELAY_20000,
-//                    )
-//                    uiDevice.wait(
-//                        Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/card_truck_go")),
-//                        DELAY_20000,
-//                    )
-//                    val cardDriveGo =
-//                        mActivityRule.activity.findViewById<MaterialCardView>(R.id.card_drive_go)
-//                    if (cardDriveGo.visibility == View.VISIBLE) {
-//                        val tvDriveDistance =
-//                            mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_drive_distance)
-//                        val tvDriveMinute =
-//                            mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_drive_minute)
-//                        val tvWalkDistance =
-//                            mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_walk_distance)
-//                        val tvWalkMinute =
-//                            mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_walk_minute)
-//                        val tvTruckDistance =
-//                            mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_truck_distance)
-//                        val tvTruckMinute =
-//                            mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_truck_minute)
-//
-//                        Assert.assertTrue(
-//                            TEST_FAILED_DISTANCE_OR_TIME_EMPTY,
-//                            tvDriveDistance.text.toString().isNotEmpty() && tvDriveMinute.text.toString().isNotEmpty() &&
-//                                tvWalkDistance.text.toString().isNotEmpty() && tvWalkMinute.text.toString().isNotEmpty() &&
-//                                tvTruckDistance.text.toString().isNotEmpty() && tvTruckMinute.text.toString().isNotEmpty(),
-//                        )
-//                    } else {
-//                        Assert.fail(TEST_FAILED_CARD_DRIVE_GO)
-//                    }
-//                } else {
-//                    Assert.fail(TEST_FAILED_SEARCH_DIRECTION)
-//                }
-//            } else {
-//                Assert.fail(TEST_FAILED_DIRECTION_CARD)
-//            }
-        } catch (_: Exception) {
-            Assert.fail(TEST_FAILED)
+        } catch (e: Exception) {
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckRouteMapAdjustedTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckRouteMapAdjustedTest.kt
@@ -8,7 +8,8 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -17,9 +18,7 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
-import com.aws.amazonlocation.DELAY_3000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
@@ -31,7 +30,6 @@ import com.aws.amazonlocation.TEST_WORD_AUBURN_SYDNEY
 import com.aws.amazonlocation.TEST_WORD_MANLY_BEACH_SYDNEY
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.textfield.TextInputEditText
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -54,12 +52,11 @@ class CheckRouteMapAdjustedTest : BaseTestMainActivity() {
             var mapbox: MapLibreMap? = null
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
+
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
                 mapbox = it
             }
-            Thread.sleep(DELAY_5000)
             val beforeZoomLevel: Double? = mapbox?.cameraPosition?.zoom
             val cardDirection =
                 mActivityRule.activity.findViewById<MaterialCardView>(R.id.card_direction)
@@ -71,7 +68,6 @@ class CheckRouteMapAdjustedTest : BaseTestMainActivity() {
                     Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/edt_search_direction")),
                     DELAY_5000,
                 )
-                Thread.sleep(DELAY_3000)
                 val edtSearchDirection =
                     mActivityRule.activity.findViewById<TextInputEditText>(R.id.edt_search_direction)
                 if (edtSearchDirection.visibility == View.VISIBLE) {
@@ -80,12 +76,10 @@ class CheckRouteMapAdjustedTest : BaseTestMainActivity() {
                             TEST_WORD_AUBURN_SYDNEY,
                         ),
                     )
-                    Thread.sleep(DELAY_2000)
                     uiDevice.wait(
                         Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion_direction")),
                         DELAY_20000,
                     )
-                    Thread.sleep(DELAY_3000)
                     val rvSearchPlacesSuggestionDirection =
                         mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion_direction)
                     rvSearchPlacesSuggestionDirection.adapter?.itemCount?.let {
@@ -99,12 +93,11 @@ class CheckRouteMapAdjustedTest : BaseTestMainActivity() {
                         }
                     }
                     onView(withId(R.id.edt_search_dest)).perform(ViewActions.typeText(TEST_WORD_MANLY_BEACH_SYDNEY))
-                    Thread.sleep(DELAY_3000)
+
                     uiDevice.wait(
                         Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion_direction")),
                         DELAY_20000,
                     )
-                    Thread.sleep(DELAY_3000)
                     rvSearchPlacesSuggestionDirection.adapter?.itemCount?.let {
                         if (it > 0) {
                             onView(withId(R.id.rv_search_places_suggestion_direction)).perform(
@@ -119,7 +112,6 @@ class CheckRouteMapAdjustedTest : BaseTestMainActivity() {
                         Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/card_drive_go")),
                         DELAY_20000,
                     )
-                    Thread.sleep(DELAY_5000)
                     if (beforeZoomLevel != null) {
                         mapbox?.cameraPosition?.zoom?.let {
                             Assert.assertTrue(TEST_FAILED_ZOOM_LEVEL_NOT_CHANGED, beforeZoomLevel != it)
@@ -134,8 +126,7 @@ class CheckRouteMapAdjustedTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_DIRECTION_CARD)
             }
         } catch (e: Exception) {
-            failTest(146, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckRouteOptionsTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckRouteOptionsTest.kt
@@ -1,28 +1,25 @@
 package com.aws.amazonlocation.ui.main
 
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_WORD_AUBURN_SYDNEY
 import com.aws.amazonlocation.TEST_WORD_MANLY_BEACH_SYDNEY
+import com.aws.amazonlocation.checkLocationPermission
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
@@ -39,20 +36,14 @@ class CheckRouteOptionsTest : BaseTestMainActivity() {
     @Test
     fun showCheckRouteOptionsTest() {
         try {
-            enableGPS(ApplicationProvider.getApplicationContext())
-            uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
+            checkLocationPermission(uiDevice)
 
             val cardDirectionTest =
                 onView(withId(R.id.card_direction)).check(matches(isDisplayed()))
             cardDirectionTest.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val sourceEdt = waitForView(CoreMatchers.allOf(withId(R.id.edt_search_direction), isDisplayed()))
             sourceEdt?.perform(replaceText(TEST_WORD_AUBURN_SYDNEY))
-
-            Thread.sleep(DELAY_2000)
 
             val suggestionListRv = waitForView(
                 CoreMatchers.allOf(
@@ -67,7 +58,6 @@ class CheckRouteOptionsTest : BaseTestMainActivity() {
                     click()
                 )
             )
-            Thread.sleep(DELAY_2000)
 
             val destinationEdt = waitForView(
                 CoreMatchers.allOf(
@@ -79,8 +69,6 @@ class CheckRouteOptionsTest : BaseTestMainActivity() {
                 click(),
                 replaceText(TEST_WORD_MANLY_BEACH_SYDNEY)
             )
-
-            Thread.sleep(DELAY_2000)
 
             val suggestionListDestRv = waitForView(
                 CoreMatchers.allOf(
@@ -96,7 +84,6 @@ class CheckRouteOptionsTest : BaseTestMainActivity() {
                 )
             )
 
-            // btnCarGoFirst
             waitForView(
                 CoreMatchers.allOf(
                     withId(R.id.card_drive_go),
@@ -119,11 +106,14 @@ class CheckRouteOptionsTest : BaseTestMainActivity() {
                 )
             )
             switchAvoidTolls?.perform(click())
-
-            Thread.sleep(DELAY_2000)
+            waitForView(
+                CoreMatchers.allOf(
+                    withId(R.id.card_drive_go),
+                    isDisplayed()
+                )
+            )
         } catch (e: Exception) {
-            failTest(221, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckRouteUserEnterMyLocationTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/CheckRouteUserEnterMyLocationTest.kt
@@ -7,7 +7,11 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -15,7 +19,6 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.GO
 import com.aws.amazonlocation.MY_LOCATION
 import com.aws.amazonlocation.R
@@ -23,7 +26,6 @@ import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_WORD_SHYAMAL
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
@@ -42,24 +44,17 @@ class CheckRouteUserEnterMyLocationTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val cardDirectionTest =
                 onView(withId(R.id.card_direction)).check(matches(isDisplayed()))
             cardDirectionTest.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val sourceEdt = waitForView(allOf(withId(R.id.edt_search_direction), isDisplayed()))
             sourceEdt?.perform(click())
-
-            Thread.sleep(DELAY_2000)
 
             val clMyLocation =
                 waitForView(allOf(withText(R.string.label_my_location), isDisplayed()))
             clMyLocation?.perform(click())
-
-            Thread.sleep(DELAY_2000)
 
             val destinationEdt = waitForView(
                 allOf(
@@ -68,8 +63,6 @@ class CheckRouteUserEnterMyLocationTest : BaseTestMainActivity() {
                 ),
             )
             destinationEdt?.perform(click(), ViewActions.replaceText(TEST_WORD_SHYAMAL))
-
-            Thread.sleep(DELAY_2000)
 
             val suggestionListRv = waitForView(
                 allOf(
@@ -107,8 +100,7 @@ class CheckRouteUserEnterMyLocationTest : BaseTestMainActivity() {
                 ),
             )
         } catch (e: Exception) {
-            failTest(121, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ConnectToAWSTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ConnectToAWSTest.kt
@@ -1,7 +1,6 @@
 package com.aws.amazonlocation.ui.main
 
 import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions
@@ -9,7 +8,6 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.*
 import com.aws.amazonlocation.actions.nestedScrollTo
@@ -46,22 +44,8 @@ class ConnectToAWSTest : BaseTestMainActivity() {
     @Test
     fun canConnectToAWSFromSettings() {
         try {
-            Thread.sleep(DELAY_2000)
-            val btnContinueToApp = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/btn_continue_to_app"))
-            if (btnContinueToApp.exists()) {
-                btnContinueToApp.click()
-                Thread.sleep(DELAY_2000)
-            }
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
-            uiDevice.findObject(By.text(ALLOW))?.click()
-            Thread.sleep(DELAY_2000)
-            enableGPS(ApplicationProvider.getApplicationContext())
-            uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
+            checkLocationPermission(uiDevice)
             val settingTabText = mActivityRule.activity.getString(R.string.menu_setting)
-
-            Thread.sleep(DELAY_2000)
 
             onView(
                 allOf(
@@ -69,9 +53,7 @@ class ConnectToAWSTest : BaseTestMainActivity() {
                     isDescendantOfA(withId(R.id.bottom_navigation_main)),
                     isDisplayed(),
                 ),
-            )
-                .perform(click())
-            Thread.sleep(DELAY_1000)
+            ).perform(click())
             Assert.assertEquals(true, bottomNavigation.menu.findItem(R.id.menu_settings).isChecked)
 
             onView(
@@ -79,43 +61,37 @@ class ConnectToAWSTest : BaseTestMainActivity() {
                     withId(R.id.cl_aws_cloudformation),
                     isDisplayed(),
                 ),
-            )
-                .perform(click())
-            Thread.sleep(DELAY_1000)
+            ).perform(click())
+
             onView(withId(R.id.edt_identity_pool_id)).perform(
                 nestedScrollTo(),
                 typeText(BuildConfig.IDENTITY_POOL_ID),
                 closeSoftKeyboard(),
             )
-            Thread.sleep(DELAY_1000)
             onView(withId(R.id.edt_user_domain)).perform(
                 nestedScrollTo(),
                 typeText(BuildConfig.USER_DOMAIN),
                 closeSoftKeyboard(),
             )
-            Thread.sleep(DELAY_1000)
             onView(withId(R.id.edt_user_pool_client_id)).perform(
                 nestedScrollTo(),
                 typeText(BuildConfig.USER_POOL_CLIENT_ID),
                 closeSoftKeyboard(),
             )
-            Thread.sleep(DELAY_1000)
             onView(withId(R.id.edt_user_pool_id)).perform(
                 nestedScrollTo(),
                 typeText(BuildConfig.USER_POOL_ID),
                 closeSoftKeyboard(),
             )
-            Thread.sleep(DELAY_1000)
             onView(withId(R.id.edt_web_socket_url)).perform(
                 nestedScrollTo(),
                 typeText(BuildConfig.WEB_SOCKET_URL),
                 closeSoftKeyboard(),
             )
-            Thread.sleep(DELAY_1000)
             val btnConnect =
                 onView(withId(R.id.btn_connect)).check(ViewAssertions.matches(isDisplayed()))
             btnConnect.perform(click())
-            Thread.sleep(DELAY_5000)
+            uiDevice.wait(Until.hasObject(By.text(mActivityRule.activity.getString(R.string.sign_in))), DELAY_5000)
             val signIn =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.sign_in)))
             Assert.assertNotNull(signIn)

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentChangeStyleTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentChangeStyleTest.kt
@@ -6,7 +6,6 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.*
 import com.aws.amazonlocation.di.AppModule
@@ -37,10 +36,7 @@ class ExploreFragmentChangeStyleTest : BaseTestMainActivity() {
     @Test
     fun testMapStyleChange() {
         try {
-            Thread.sleep(DELAY_2000)
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-
-            Thread.sleep(DELAY_2000)
 
             goToMapStyles()
 
@@ -49,18 +45,14 @@ class ExploreFragmentChangeStyleTest : BaseTestMainActivity() {
             waitForView(allOf(withContentDescription(MAP_3), isDisplayed()))?.perform(click())
             waitForView(allOf(withContentDescription(MAP_4), isDisplayed()))?.perform(click())
         } catch (e: Exception) {
-            failTest(147, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
     private fun goToMapStyles() {
         val cardMap = waitForView(allOf(withId(R.id.card_map), isDisplayed()))
         cardMap?.perform(click())
-
-        Thread.sleep(DELAY_2000)
         swipeUp()
-        Thread.sleep(DELAY_2000)
     }
 
     private fun swipeUp(): UiDevice? {

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentEnableLocation.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentEnableLocation.kt
@@ -1,29 +1,15 @@
 package com.aws.amazonlocation.ui.main
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObjectNotFoundException
-import androidx.test.uiautomator.UiSelector
-import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ALLOW
-import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
-import com.aws.amazonlocation.DELAY_4000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED
-import com.aws.amazonlocation.WHILE_USING_THE_APP
-import com.aws.amazonlocation.WHILE_USING_THE_APP_CAPS
-import com.aws.amazonlocation.WHILE_USING_THE_APP_ALLOW
+import com.aws.amazonlocation.checkLocationPermission
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.waitUntil
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
@@ -35,68 +21,32 @@ import org.maplibre.android.maps.MapView
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class ExploreFragmentEnableLocation : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
     fun testMapEnableLocation() {
         try {
-            Thread.sleep(DELAY_2000)
-            val btnContinueToApp = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/btn_continue_to_app"))
-            if (btnContinueToApp.exists()) {
-                btnContinueToApp.click()
-                Thread.sleep(DELAY_2000)
-                try {
-                    Thread.sleep(DELAY_2000)
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
-                    uiDevice.findObject(By.text(ALLOW))?.click()
-                    Thread.sleep(DELAY_2000)
-                    enableGPS(ApplicationProvider.getApplicationContext())
-                    uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-                    var mapbox: MapLibreMap? = null
-                    val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
-                    mapView.getMapAsync {
-                        mapbox = it
-                    }
-                    Thread.sleep(DELAY_4000)
-                    waitUntil(DELAY_5000, 25) {
-                        mapbox?.locationComponent?.isLocationComponentActivated == true && mapbox?.locationComponent?.isLocationComponentEnabled == true
-                    }
-                    Assert.assertTrue(TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED, mapbox?.locationComponent?.isLocationComponentActivated == true && mapbox?.locationComponent?.isLocationComponentEnabled == true)
-                } catch (e: UiObjectNotFoundException) {
-                    failTest(67, e)
-                    Assert.fail(TEST_FAILED)
+            checkLocationPermission(uiDevice)
+            try {
+                var mapbox: MapLibreMap? = null
+                val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
+                mapView.getMapAsync {
+                    mapbox = it
                 }
-            } else {
-                try {
-                    Thread.sleep(DELAY_2000)
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
-                    uiDevice.findObject(By.text(ALLOW))?.click()
-                    Thread.sleep(DELAY_2000)
-                    enableGPS(ApplicationProvider.getApplicationContext())
-                    uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-                    var mapbox: MapLibreMap? = null
-                    val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
-                    mapView.getMapAsync {
-                        mapbox = it
-                    }
-                    Thread.sleep(DELAY_4000)
-                    waitUntil(DELAY_5000, 25) {
-                        mapbox?.locationComponent?.isLocationComponentActivated == true && mapbox?.locationComponent?.isLocationComponentEnabled == true
-                    }
-                    Assert.assertTrue(TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED, mapbox?.locationComponent?.isLocationComponentActivated == true && mapbox?.locationComponent?.isLocationComponentEnabled == true)
-                } catch (e: UiObjectNotFoundException) {
-                    failTest(85, e)
-                    Assert.fail(TEST_FAILED)
+                waitUntil(DELAY_5000, 25) {
+                    mapbox?.locationComponent?.isLocationComponentActivated == true &&
+                        mapbox?.locationComponent?.isLocationComponentEnabled == true
                 }
+                Assert.assertTrue(
+                    TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED,
+                    mapbox?.locationComponent?.isLocationComponentActivated == true &&
+                        mapbox?.locationComponent?.isLocationComponentEnabled == true,
+                )
+            } catch (e: UiObjectNotFoundException) {
+                Assert.fail("$TEST_FAILED ${e.message}")
             }
         } catch (e: Exception) {
-            failTest(90, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentLiveNavigationTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentLiveNavigationTest.kt
@@ -6,7 +6,11 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -21,7 +25,6 @@ import com.aws.amazonlocation.TEST_FAILED_LIST
 import com.aws.amazonlocation.TEST_WORD_SHYAMAL_CROSS_ROAD
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.waitForView
 import com.google.android.material.textfield.TextInputEditText
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -111,8 +114,7 @@ class ExploreFragmentLiveNavigationTest : BaseTestMainActivity() {
             // navListView
             waitForView(allOf(withId(R.id.rv_navigation_list), isDisplayed(), hasMinimumChildCount(1)))
         } catch (e: Exception) {
-            failTest(136, e)
-            Assert.fail(TEST_FAILED_LIST)
+            Assert.fail("$TEST_FAILED_LIST ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapCurrentLocationTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapCurrentLocationTest.kt
@@ -8,13 +8,11 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.junit.Assert
@@ -34,7 +32,6 @@ class ExploreFragmentMapCurrentLocationTest : BaseTestMainActivity() {
             enableGPS(ApplicationProvider.getApplicationContext())
             var mapbox: MapLibreMap? = null
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
@@ -42,8 +39,7 @@ class ExploreFragmentMapCurrentLocationTest : BaseTestMainActivity() {
             }
             Assert.assertTrue(TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED, mapbox?.locationComponent?.isLocationComponentActivated == true && mapbox?.locationComponent?.isLocationComponentEnabled == true)
         } catch (e: Exception) {
-            failTest(61, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapFunctionWithoutAwsLoginTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapFunctionWithoutAwsLoginTest.kt
@@ -9,7 +9,8 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -18,10 +19,8 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED_BUTTON_DIRECTION
@@ -59,27 +58,22 @@ class ExploreFragmentMapFunctionWithoutAwsLoginTest : BaseTestMainActivity() {
     fun showMapFunctionWithoutAwsLoginTest() {
         enableGPS(ApplicationProvider.getApplicationContext())
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-        Thread.sleep(DELAY_2000)
         val map = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/mapView"))
         if (map.exists()) {
             onView(withId(R.id.mapView)).perform(swipeLeft())
         }
-        Thread.sleep(DELAY_1000)
 
         val btnCardMap =
             onView(withId(R.id.card_map)).check(ViewAssertions.matches(isDisplayed()))
         btnCardMap?.perform(click())
-        Thread.sleep(DELAY_1000)
 
         uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.map_monochrome)))
             ?.click()
 
-        Thread.sleep(DELAY_2000)
         val ivMapStyleClose =
             onView(withId(R.id.iv_map_style_close)).check(ViewAssertions.matches(isDisplayed()))
         ivMapStyleClose?.perform(click())
 
-        Thread.sleep(DELAY_2000)
         val edtSearch =
             onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
         edtSearch?.perform(click())

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapLanguageTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapLanguageTest.kt
@@ -6,10 +6,8 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
-import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.*
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.utils.*
@@ -39,17 +37,7 @@ class ExploreFragmentMapLanguageTest : BaseTestMainActivity() {
     @Test
     fun testMapLanguageChangeTest() {
         try {
-            val btnContinueToApp = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/btn_continue_to_app"))
-            if (btnContinueToApp.exists()) {
-                btnContinueToApp.click()
-                Thread.sleep(DELAY_2000)
-            }
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
-            uiDevice.findObject(By.text(ALLOW))?.click()
-            enableGPS(ApplicationProvider.getApplicationContext())
-            uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
+            checkLocationPermission(uiDevice)
 
             goToMapStyles()
 
@@ -64,8 +52,7 @@ class ExploreFragmentMapLanguageTest : BaseTestMainActivity() {
             val description = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/tv_map_language_description"))
             Assert.assertTrue(TEST_FAILED_LANGUAGE, description.text.contains(TEST_WORD_LANGUAGE_AR))
         } catch (e: Exception) {
-            failTest(147, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapLoadingTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapLoadingTest.kt
@@ -1,7 +1,6 @@
 package com.aws.amazonlocation.ui.main
 
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -11,11 +10,9 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.junit.Assert
@@ -32,12 +29,10 @@ class ExploreFragmentMapLoadingTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
             val map = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/mapView"))
             Assert.assertEquals(AMAZON_MAP_READY, map.contentDescription)
         } catch (e: Exception) {
-            failTest(56, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapLocateMeButtonTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapLocateMeButtonTest.kt
@@ -11,16 +11,13 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED
 import com.aws.amazonlocation.actions.swipeLeft
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.junit.Assert
@@ -40,22 +37,18 @@ class ExploreFragmentMapLocateMeButtonTest : BaseTestMainActivity() {
             var mapbox: MapLibreMap? = null
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
                 mapbox = it
             }
             Espresso.onView(withId(R.id.mapView)).perform(swipeLeft())
-            Thread.sleep(DELAY_1000)
 
             val cardNavigation = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/card_navigation"))
             cardNavigation.click()
-            Thread.sleep(DELAY_2000)
             Assert.assertTrue(TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED, mapbox?.locationComponent?.isLocationComponentActivated == true && mapbox?.locationComponent?.isLocationComponentEnabled == true)
         } catch (e: Exception) {
-            failTest(71, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapZoomInOutTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMapZoomInOutTest.kt
@@ -2,7 +2,7 @@ package com.aws.amazonlocation.ui.main
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -11,11 +11,9 @@ import androidx.test.uiautomator.Until.hasObject
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_3000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_MAP_NOT_FOUND
@@ -26,7 +24,6 @@ import com.aws.amazonlocation.actions.pinchIn
 import com.aws.amazonlocation.actions.pinchOut
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.utils.retry_rule.Retry
 import com.aws.amazonlocation.waitUntil
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -49,17 +46,14 @@ class ExploreFragmentMapZoomInOutTest : BaseTestMainActivity() {
             enableGPS(ApplicationProvider.getApplicationContext())
             var mapbox: MapLibreMap? = null
             uiDevice.wait(hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
                 mapbox = it
             }
-            Thread.sleep(DELAY_5000)
             val beforeZoomLevel: Double? = mapbox?.cameraPosition?.zoom
             uiDevice.wait(hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/mapView")), DELAY_10000)
             onView(withId(R.id.mapView)).perform(pinchOut(), pinchOut(), pinchOut(), pinchOut(), pinchOut(), pinchOut())
-            Thread.sleep(DELAY_5000)
             if (beforeZoomLevel != null) {
                 waitUntil(DELAY_3000, 25) {
                     mapbox?.cameraPosition?.zoom?.let {
@@ -75,8 +69,7 @@ class ExploreFragmentMapZoomInOutTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_ZOOM_LEVEL)
             }
         } catch (e: Exception) {
-            failTest(86, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
@@ -86,17 +79,14 @@ class ExploreFragmentMapZoomInOutTest : BaseTestMainActivity() {
         try {
             var mapbox: MapLibreMap? = null
             uiDevice.wait(hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
                 mapbox = it
             }
-            Thread.sleep(DELAY_5000)
             val beforeZoomLevel: Double? = mapbox?.cameraPosition?.zoom
             uiDevice.wait(hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/mapView")), DELAY_10000)
             onView(withId(R.id.mapView)).perform(pinchIn(), pinchIn(), pinchIn(), pinchIn(), pinchIn(), pinchIn())
-            Thread.sleep(DELAY_5000)
             if (beforeZoomLevel != null) {
                 waitUntil(DELAY_3000, 25) {
                     mapbox?.cameraPosition?.zoom?.let {
@@ -112,8 +102,7 @@ class ExploreFragmentMapZoomInOutTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_ZOOM_LEVEL)
             }
         } catch (e: Exception) {
-            failTest(115, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
@@ -123,13 +112,11 @@ class ExploreFragmentMapZoomInOutTest : BaseTestMainActivity() {
         try {
             var mapbox: MapLibreMap? = null
             uiDevice.wait(hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
                 mapbox = it
             }
-            Thread.sleep(DELAY_5000)
             val beforeZoomLevel: Double? = mapbox?.cameraPosition?.zoom
             uiDevice.wait(hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/mapView")), DELAY_10000)
             val map = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/mapView"))
@@ -138,7 +125,6 @@ class ExploreFragmentMapZoomInOutTest : BaseTestMainActivity() {
             } else {
                 Assert.fail(TEST_FAILED_MAP_NOT_FOUND)
             }
-            Thread.sleep(DELAY_5000)
             if (beforeZoomLevel != null) {
                 waitUntil(DELAY_3000, 25) {
                     mapbox?.cameraPosition?.zoom?.let {
@@ -154,8 +140,7 @@ class ExploreFragmentMapZoomInOutTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_ZOOM_LEVEL)
             }
         } catch (e: Exception) {
-            failTest(149, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMaxZoomInOutTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentMaxZoomInOutTest.kt
@@ -12,15 +12,12 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_MAX_ZOOM_NOT_REACHED
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.junit.Assert
@@ -40,7 +37,6 @@ class ExploreFragmentMaxZoomInOutTest : BaseTestMainActivity() {
             enableGPS(ApplicationProvider.getApplicationContext())
             var mapbox: MapLibreMap? = null
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
@@ -53,7 +49,6 @@ class ExploreFragmentMaxZoomInOutTest : BaseTestMainActivity() {
                 if (map.exists()) {
                     map.pinchIn(50, 15)
                 }
-                Thread.sleep(DELAY_2000)
                 if (beforeZoomLevel != null) {
                     mapbox?.cameraPosition?.zoom?.let {
                         if (beforeZoomLevel == it) {
@@ -67,8 +62,7 @@ class ExploreFragmentMaxZoomInOutTest : BaseTestMainActivity() {
             }
             Assert.assertTrue(TEST_FAILED_MAX_ZOOM_NOT_REACHED, isMaxZoomInReach)
         } catch (e: Exception) {
-            failTest(86, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
@@ -77,7 +71,6 @@ class ExploreFragmentMaxZoomInOutTest : BaseTestMainActivity() {
         try {
             var mapbox: MapLibreMap? = null
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
@@ -90,7 +83,6 @@ class ExploreFragmentMaxZoomInOutTest : BaseTestMainActivity() {
                 if (map.exists()) {
                     onView(withId(R.id.mapView)).perform(ViewActions.doubleClick())
                 }
-                Thread.sleep(DELAY_2000)
                 if (beforeZoomLevel != null) {
                     mapbox?.cameraPosition?.zoom?.let {
                         if (beforeZoomLevel == it) {
@@ -104,8 +96,7 @@ class ExploreFragmentMaxZoomInOutTest : BaseTestMainActivity() {
             }
             Assert.assertTrue(TEST_FAILED_MAX_ZOOM_NOT_REACHED, isMaxZoomInReach)
         } catch (e: Exception) {
-            failTest(123, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentPoliticalViewTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentPoliticalViewTest.kt
@@ -40,10 +40,8 @@ class ExploreFragmentPoliticalViewTest : BaseTestMainActivity() {
     @Test
     fun testPoliticalViewChange() {
         try {
-            Thread.sleep(DELAY_2000)
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
 
-            Thread.sleep(DELAY_2000)
 
             goToMapStyles()
 
@@ -51,28 +49,21 @@ class ExploreFragmentPoliticalViewTest : BaseTestMainActivity() {
                 onView(withId(R.id.cl_political_view)).check(matches(isDisplayed()))
             clPoliticalView.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val etSearchCountry =
                 onView(withId(R.id.et_search_country)).check(matches(isDisplayed()))
             etSearchCountry.perform(click())
-
-            Thread.sleep(DELAY_1000)
             onView(withId(R.id.et_search_country)).perform(replaceText(TEST_WORD_ARG))
 
-            Thread.sleep(DELAY_1000)
+            uiDevice.wait(Until.hasObject(By.text(mActivityRule.activity.getString(R.string.description_arg))), DELAY_5000)
 
             val rbCountry =
                 onView(withId(R.id.rb_country)).check(matches(isDisplayed()))
             rbCountry.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val tvPoliticalDescription = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/tv_political_description"))
             Assert.assertTrue(TEST_FAILED_COUNTRY, tvPoliticalDescription.text.contains(TEST_WORD_ARG))
         } catch (e: Exception) {
-            failTest(147, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
@@ -80,9 +71,7 @@ class ExploreFragmentPoliticalViewTest : BaseTestMainActivity() {
         val cardMap = waitForView(allOf(withId(R.id.card_map), isDisplayed()))
         cardMap?.perform(click())
 
-        Thread.sleep(DELAY_2000)
         swipeUp()
-        Thread.sleep(DELAY_2000)
     }
 
     private fun swipeUp(): UiDevice? {

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchByCategoriesTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchByCategoriesTest.kt
@@ -6,7 +6,9 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -14,7 +16,6 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_COUNT_NOT_GREATER_THAN_ZERO
@@ -22,9 +23,10 @@ import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_WORD_SCHOOL
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -39,13 +41,13 @@ class ExploreFragmentSearchByCategoriesTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
             edtSearch.perform(click())
             onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_WORD_SCHOOL))
-            Thread.sleep(DELAY_15000)
+
+            waitForView(allOf(withId(R.id.rv_search_places_suggestion), isDisplayed(), hasMinimumChildCount(1)))
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
@@ -56,8 +58,7 @@ class ExploreFragmentSearchByCategoriesTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(81, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchCollapseTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchCollapseTest.kt
@@ -7,19 +7,15 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.rule.ActivityTestRule
-import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ACCESS_COARSE_LOCATION
-import com.aws.amazonlocation.ACCESS_FINE_LOCATION
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
@@ -29,11 +25,9 @@ import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.card.MaterialCardView
-import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
@@ -53,9 +47,7 @@ class ExploreFragmentSearchCollapseTest : BaseTestMainActivity() {
         val edtSearch =
             onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
         edtSearch.perform(click())
-        Thread.sleep(DELAY_1000)
         edtSearch.perform(ViewActions.closeSoftKeyboard())
-        Thread.sleep(DELAY_1000)
         val clSearchSheet =
             mActivityRule.activity.findViewById<ConstraintLayout>(R.id.bottom_sheet_search)
         if (clSearchSheet.visibility == View.VISIBLE) {

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchExistsTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchExistsTest.kt
@@ -1,33 +1,24 @@
 package com.aws.amazonlocation.ui.main
 
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.rule.ActivityTestRule
-import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ACCESS_COARSE_LOCATION
-import com.aws.amazonlocation.ACCESS_FINE_LOCATION
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_HEIGHT_NOT_GREATER
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.google.android.material.textfield.TextInputEditText
-import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
@@ -41,13 +32,11 @@ class ExploreFragmentSearchExistsTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             uiDevice.wait(
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/edt_search_places")),
                 DELAY_20000
             )
-            Thread.sleep(DELAY_2000)
             val edtSearchPlaces =
                 mActivityRule.activity.findViewById<TextInputEditText>(R.id.edt_search_places)
             val point = IntArray(2)
@@ -55,8 +44,7 @@ class ExploreFragmentSearchExistsTest : BaseTestMainActivity() {
             val screenHeight = mActivityRule.activity.window.decorView.height / 2
             Assert.assertTrue(TEST_FAILED_HEIGHT_NOT_GREATER, point[1] + edtSearchPlaces.height > screenHeight)
         } catch (e: Exception) {
-            failTest(67, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchGeocodeReversedTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchGeocodeReversedTest.kt
@@ -5,22 +5,18 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
-import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.rule.ActivityTestRule
-import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ACCESS_COARSE_LOCATION
-import com.aws.amazonlocation.ACCESS_FINE_LOCATION
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
@@ -29,12 +25,11 @@ import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_GEOCODE_1
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
-import dagger.hilt.android.testing.HiltAndroidRule
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
@@ -48,8 +43,6 @@ class ExploreFragmentSearchGeocodeReversedTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
-
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
             edtSearch.perform(click())
@@ -58,7 +51,8 @@ class ExploreFragmentSearchGeocodeReversedTest : BaseTestMainActivity() {
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion")),
                 DELAY_20000
             )
-            Thread.sleep(DELAY_2000)
+
+            waitForView(allOf(withId(R.id.rv_search_places_suggestion), isDisplayed(), hasMinimumChildCount(1)))
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
@@ -69,8 +63,7 @@ class ExploreFragmentSearchGeocodeReversedTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(81, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchLocationByAddressTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchLocationByAddressTest.kt
@@ -5,7 +5,9 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -13,15 +15,15 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_ADDRESS
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -36,21 +38,19 @@ class ExploreFragmentSearchLocationByAddressTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(matches(isDisplayed()))
             edtSearch.perform(click())
             onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_ADDRESS))
-            Thread.sleep(DELAY_15000)
+            waitForView(allOf(withId(R.id.rv_search_places_suggestion), isDisplayed(), hasMinimumChildCount(1)))
             onView(withId(R.id.rv_search_places_suggestion)).check(
                 matches(
                     hasMinimumChildCount(1),
                 ),
             )
         } catch (e: Exception) {
-            failTest(80, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchLocationByGeocodeTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchLocationByGeocodeTest.kt
@@ -1,37 +1,27 @@
 package com.aws.amazonlocation.ui.main
 
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
-import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ALLOW
-import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_COUNT_NOT_GREATER_THAN_ZERO
 import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_GEOCODE
-import com.aws.amazonlocation.WHILE_USING_THE_APP
-import com.aws.amazonlocation.WHILE_USING_THE_APP_ALLOW
-import com.aws.amazonlocation.WHILE_USING_THE_APP_CAPS
+import com.aws.amazonlocation.checkLocationPermission
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -44,25 +34,13 @@ class ExploreFragmentSearchLocationByGeocodeTest : BaseTestMainActivity() {
     @Test
     fun showSearchLocationByGeocodeTest() {
         try {
-            val btnContinueToApp = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/btn_continue_to_app"))
-            if (btnContinueToApp.exists()) {
-                btnContinueToApp.click()
-                Thread.sleep(DELAY_2000)
-            }
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
-            uiDevice.findObject(By.text(ALLOW))?.click()
-            Thread.sleep(DELAY_2000)
-            enableGPS(ApplicationProvider.getApplicationContext())
-            uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
+            checkLocationPermission(uiDevice)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
             edtSearch.perform(click())
             onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_GEOCODE))
-            Thread.sleep(DELAY_15000)
+            waitForView(allOf(withId(R.id.rv_search_places_suggestion), isDisplayed(), hasMinimumChildCount(1)))
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
@@ -73,8 +51,7 @@ class ExploreFragmentSearchLocationByGeocodeTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(80, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchNonExistingLocationTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchNonExistingLocationTest.kt
@@ -7,32 +7,25 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.rule.ActivityTestRule
-import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ACCESS_COARSE_LOCATION
-import com.aws.amazonlocation.ACCESS_FINE_LOCATION
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_MATCHING_TEXT_NOT_VISIBLE
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
-import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
@@ -46,7 +39,6 @@ class ExploreFragmentSearchNonExistingLocationTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
@@ -56,13 +48,11 @@ class ExploreFragmentSearchNonExistingLocationTest : BaseTestMainActivity() {
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/tv_no_matching_found")),
                 DELAY_20000
             )
-            Thread.sleep(DELAY_2000)
             val tvNoMatchingPlaceFound =
                 mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_no_matching_found)
             Assert.assertTrue(TEST_FAILED_NO_MATCHING_TEXT_NOT_VISIBLE, tvNoMatchingPlaceFound.visibility == View.VISIBLE)
         } catch (e: Exception) {
-            failTest(73, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchResultTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchResultTest.kt
@@ -6,16 +6,16 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_COUNT_NOT_GREATER_THAN_ONE
@@ -23,9 +23,10 @@ import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_WORD
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -40,13 +41,12 @@ class ExploreFragmentSearchResultTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
             edtSearch.perform(click())
             onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_WORD))
-            Thread.sleep(DELAY_10000)
+            waitForView(allOf(withId(R.id.rv_search_places_suggestion), isDisplayed(), hasMinimumChildCount(1)))
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
@@ -57,8 +57,7 @@ class ExploreFragmentSearchResultTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(81, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchTotalResultTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/ExploreFragmentSearchTotalResultTest.kt
@@ -6,17 +6,16 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
-import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_COUNT_NOT_GREATER_THEN_TWO
@@ -24,8 +23,10 @@ import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_WORD_RIO_TINTO
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -40,16 +41,12 @@ class ExploreFragmentSearchTotalResultTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(ViewAssertions.matches(isDisplayed()))
             edtSearch.perform(click())
             onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_WORD_RIO_TINTO))
-            uiDevice.wait(
-                Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion")),
-                DELAY_20000
-            )
+            waitForView(allOf(withId(R.id.rv_search_places_suggestion), isDisplayed(), hasMinimumChildCount(1)))
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/GeofenceDeleteTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/GeofenceDeleteTest.kt
@@ -1,45 +1,45 @@
 package com.aws.amazonlocation.ui.main
 
-import android.Manifest.permission.ACCESS_COARSE_LOCATION
-import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.view.View
 import android.widget.SeekBar
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.rule.ActivityTestRule
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.uiautomator.*
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.actions.clickOnViewChild
 import com.aws.amazonlocation.actions.clickXYPercent
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.getRandom0_01To1_0
 import com.aws.amazonlocation.getRandom1To100
 import com.aws.amazonlocation.getRandomGeofenceName
-import dagger.hilt.android.testing.HiltAndroidRule
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers
 import org.hamcrest.core.AllOf.allOf
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
-import java.util.*
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
@@ -56,7 +56,6 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
     fun deleteGeoFenceTest() {
         try {
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             onView(
                 allOf(
@@ -64,8 +63,6 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
                     isDisplayed(),
                 ),
             ).perform(click())
-
-            Thread.sleep(DELAY_1000)
 
             uiDevice.wait(
                 Until.gone(By.res("${BuildConfig.APPLICATION_ID}:id/cl_search_loader_geofence_list")),
@@ -77,12 +74,10 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
             deleteGeoFence()
 
             if (initialCount == null || updatedCount == null || initialCount == updatedCount) {
-                failTest(76, null)
                 Assert.fail(TEST_FAILED)
             }
         } catch (e: Exception) {
-            failTest(82, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
@@ -92,7 +87,7 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
         val emptyContainer = mActivityRule.activity.findViewById<View>(R.id.cl_empty_geofence_list)
         if (emptyContainer.isVisible) {
             geofenceName = getRandomGeofenceName()
-            Thread.sleep(DELAY_1000)
+
             onView(
                 allOf(
                     withId(R.id.btn_add_geofence),
@@ -101,8 +96,7 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
                 ),
             ).perform(click())
 
-            Thread.sleep(DELAY_1000)
-
+            waitForView(CoreMatchers.allOf(withId(R.id.mapView), isDisplayed()))
             onView(
                 withId(R.id.mapView),
             ).perform(
@@ -112,18 +106,18 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
                 ),
             )
 
-            Thread.sleep(DELAY_1000)
-
             val seekbar = mActivityRule.activity.findViewById<SeekBar>(R.id.seekbar_geofence_radius)
             seekbar.progress = ((seekbar.max - seekbar.min) * getRandom0_01To1_0()).toInt()
 
-            Thread.sleep(DELAY_1000)
-
             onView(withId(R.id.edt_enter_geofence_name)).perform(typeText(geofenceName))
-            Thread.sleep(DELAY_1000)
             onView(withId(R.id.btn_add_geofence_save)).perform(click())
-            Thread.sleep(DELAY_1000)
-            uiDevice.wait(Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_geofence")), DELAY_5000)
+            waitForView(
+                CoreMatchers.allOf(
+                    withId(R.id.rv_geofence),
+                    isDisplayed(),
+                    hasMinimumChildCount(1)
+                )
+            )
 
             onView(withId(R.id.rv_geofence)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
@@ -137,7 +131,6 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
                     holder.itemView.findViewById<AppCompatTextView>(R.id.tv_geofence_address_type).text.toString()
             }
         }
-        Thread.sleep(DELAY_1000)
         val adapter = rv.adapter
         adapter?.let {
             initialCount = it.itemCount
@@ -155,7 +148,6 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
                 clickOnViewChild(R.id.iv_delete_geofence),
             ),
         )
-        Thread.sleep(DELAY_1000)
         onView(withText(mActivityRule.activity.getString(R.string.ok))).perform(click())
 
         uiDevice.wait(
@@ -167,7 +159,6 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
             Until.gone(By.res("${BuildConfig.APPLICATION_ID}:id/cl_search_loader_geofence_list")),
             DELAY_5000,
         )
-        Thread.sleep(DELAY_1000)
         val iCount = initialCount
         if (iCount != null) {
             updatedCount = if (iCount > 1) {
@@ -180,7 +171,6 @@ class GeofenceDeleteTest : BaseTestMainActivity() {
                 0
             }
         } else {
-            failTest(181, null)
             Assert.fail(TEST_FAILED)
         }
     }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/GeofenceEditTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/GeofenceEditTest.kt
@@ -1,49 +1,48 @@
 package com.aws.amazonlocation.ui.main
 
-import android.Manifest.permission.ACCESS_COARSE_LOCATION
-import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.view.View
 import android.widget.SeekBar
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.rule.ActivityTestRule
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.uiautomator.*
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.actions.clickXYPercent
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.getRandom0_01To1_0
 import com.aws.amazonlocation.getRandom1To100
 import com.aws.amazonlocation.getRandomGeofenceName
-import dagger.hilt.android.testing.HiltAndroidRule
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import kotlin.properties.Delegates
+import org.hamcrest.CoreMatchers
 import org.hamcrest.core.AllOf.allOf
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
-import java.util.*
-import kotlin.properties.Delegates
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class GeofenceEditTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     private lateinit var geofenceName: String
@@ -53,7 +52,6 @@ class GeofenceEditTest : BaseTestMainActivity() {
     fun editGeoFenceTest() {
         try {
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             onView(
                 allOf(
@@ -62,9 +60,10 @@ class GeofenceEditTest : BaseTestMainActivity() {
                 ),
             ).perform(click())
 
-            Thread.sleep(DELAY_1000)
-
-            uiDevice.wait(Until.gone(By.res("${BuildConfig.APPLICATION_ID}:id/cl_search_loader_geofence_list")), DELAY_5000)
+            uiDevice.wait(
+                Until.gone(By.res("${BuildConfig.APPLICATION_ID}:id/cl_search_loader_geofence_list")),
+                DELAY_5000,
+            )
 
             createOrGetGeoFence()
 
@@ -72,8 +71,7 @@ class GeofenceEditTest : BaseTestMainActivity() {
 
             verifyGeoFenceUpdate()
         } catch (e: Exception) {
-            failTest(73, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
@@ -84,7 +82,6 @@ class GeofenceEditTest : BaseTestMainActivity() {
 
         if (emptyContainer.isVisible) {
             geofenceName = getRandomGeofenceName()
-            Thread.sleep(DELAY_1000)
             onView(
                 allOf(
                     withId(R.id.btn_add_geofence),
@@ -93,8 +90,7 @@ class GeofenceEditTest : BaseTestMainActivity() {
                 ),
             ).perform(click())
 
-            Thread.sleep(DELAY_1000)
-
+            waitForView(CoreMatchers.allOf(withId(R.id.mapView), isDisplayed()))
             onView(
                 withId(R.id.mapView),
             ).perform(
@@ -104,28 +100,45 @@ class GeofenceEditTest : BaseTestMainActivity() {
                 ),
             )
 
-            Thread.sleep(DELAY_1000)
-
             val seekbar = mActivityRule.activity.findViewById<SeekBar>(R.id.seekbar_geofence_radius)
             seekbar.progress = ((seekbar.max - seekbar.min) * getRandom0_01To1_0()).toInt()
 
-            Thread.sleep(DELAY_1000)
-
             onView(withId(R.id.edt_enter_geofence_name)).perform(typeText(geofenceName))
-            Thread.sleep(DELAY_1000)
+
             onView(withId(R.id.btn_add_geofence_save)).perform(click())
 
-            uiDevice.wait(Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_geofence")), DELAY_5000)
+            waitForView(
+                CoreMatchers.allOf(
+                    withId(R.id.rv_geofence),
+                    isDisplayed(),
+                    hasMinimumChildCount(1),
+                ),
+            )
 
-            onView(withId(R.id.rv_geofence)).perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(hasDescendant(withText(geofenceName))))
+            onView(withId(R.id.rv_geofence)).perform(
+                RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+                    hasDescendant(withText(geofenceName)),
+                ),
+            )
         } else {
             val holder = rv.findViewHolderForAdapterPosition(0)
-            geofenceName = holder?.itemView?.findViewById<AppCompatTextView>(R.id.tv_geofence_address_type)?.text.toString()
+            geofenceName =
+                holder
+                    ?.itemView
+                    ?.findViewById<AppCompatTextView>(R.id.tv_geofence_address_type)
+                    ?.text
+                    .toString()
         }
     }
 
     private fun editGeoFence() {
-        Thread.sleep(DELAY_1000)
+        waitForView(
+            CoreMatchers.allOf(
+                withId(R.id.rv_geofence),
+                isDisplayed(),
+                hasMinimumChildCount(1),
+            ),
+        )
         onView(withId(R.id.rv_geofence)).perform(
             RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                 hasDescendant(
@@ -135,21 +148,32 @@ class GeofenceEditTest : BaseTestMainActivity() {
             ),
         )
 
-        Thread.sleep(DELAY_1000)
-
         val seekbar = mActivityRule.activity.findViewById<SeekBar>(R.id.seekbar_geofence_radius)
         seekbar.progress = ((seekbar.max - seekbar.min) * getRandom0_01To1_0()).toInt()
-        Thread.sleep(DELAY_1000)
+
         updatedRadius = seekbar.progress
 
         onView(withId(R.id.btn_add_geofence_save)).perform(click())
 
-        uiDevice.wait(Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_geofence")), DELAY_5000)
+        uiDevice.wait(
+            Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_geofence")),
+            DELAY_5000,
+        )
     }
 
     private fun verifyGeoFenceUpdate() {
-        Thread.sleep(DELAY_1000)
-        onView(withId(R.id.rv_geofence)).perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(hasDescendant(withText(geofenceName))))
+        waitForView(
+            CoreMatchers.allOf(
+                withId(R.id.rv_geofence),
+                isDisplayed(),
+                hasMinimumChildCount(1),
+            ),
+        )
+        onView(withId(R.id.rv_geofence)).perform(
+            RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+                hasDescendant(withText(geofenceName)),
+            ),
+        )
         onView(withId(R.id.rv_geofence)).perform(
             RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                 hasDescendant(
@@ -158,11 +182,9 @@ class GeofenceEditTest : BaseTestMainActivity() {
                 click(),
             ),
         )
-        Thread.sleep(DELAY_1000)
         val seekbar = mActivityRule.activity.findViewById<SeekBar>(R.id.seekbar_geofence_radius)
 
         if (seekbar.progress != updatedRadius) {
-            failTest(163, null)
             Assert.fail(TEST_FAILED)
         }
     }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/RouteOptionShowingTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/RouteOptionShowingTest.kt
@@ -9,7 +9,13 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -17,7 +23,6 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.GO
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
@@ -25,7 +30,6 @@ import com.aws.amazonlocation.TEST_FAILED_DRIVE_OR_WALK_OR_TRUCK_OPTION_NOT_VISI
 import com.aws.amazonlocation.TEST_WORD_SHYAMAL_CROSS_ROAD
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
@@ -44,24 +48,17 @@ class RouteOptionShowingTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val cardDirectionTest =
                 onView(withId(R.id.card_direction)).check(matches(isDisplayed()))
             cardDirectionTest.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val sourceEdt = waitForView(CoreMatchers.allOf(withId(R.id.edt_search_direction), isDisplayed()))
             sourceEdt?.perform(click())
-
-            Thread.sleep(DELAY_2000)
 
             val clMyLocation =
                 waitForView(CoreMatchers.allOf(withText(R.string.label_my_location), isDisplayed()))
             clMyLocation?.perform(click())
-
-            Thread.sleep(DELAY_2000)
 
             val destinationEdt = waitForView(
                 CoreMatchers.allOf(
@@ -70,8 +67,6 @@ class RouteOptionShowingTest : BaseTestMainActivity() {
                 ),
             )
             destinationEdt?.perform(click(), ViewActions.replaceText(TEST_WORD_SHYAMAL_CROSS_ROAD))
-
-            Thread.sleep(DELAY_2000)
 
             val suggestionListRv = waitForView(
                 CoreMatchers.allOf(
@@ -125,14 +120,13 @@ class RouteOptionShowingTest : BaseTestMainActivity() {
             lateinit var clTruck: ConstraintLayout
 
             getInstrumentation().runOnMainSync {
-                clDrive = mActivityRule.activity.findViewById<ConstraintLayout>(R.id.cl_drive)
-                clWalk = mActivityRule.activity.findViewById<ConstraintLayout>(R.id.cl_walk)
-                clTruck = mActivityRule.activity.findViewById<ConstraintLayout>(R.id.cl_truck)
+                clDrive = mActivityRule.activity.findViewById(R.id.cl_drive)
+                clWalk = mActivityRule.activity.findViewById(R.id.cl_walk)
+                clTruck = mActivityRule.activity.findViewById(R.id.cl_truck)
                 Assert.assertTrue(TEST_FAILED_DRIVE_OR_WALK_OR_TRUCK_OPTION_NOT_VISIBLE, clDrive.isVisible && clWalk.isVisible && clTruck.isVisible)
             }
         } catch (e: Exception) {
-            failTest(129, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/RouteReverseBetweenFormToTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/RouteReverseBetweenFormToTest.kt
@@ -7,7 +7,11 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -15,8 +19,6 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
-import com.aws.amazonlocation.DELAY_3000
 import com.aws.amazonlocation.GO
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
@@ -24,7 +26,6 @@ import com.aws.amazonlocation.TEST_FAILED_INVALID_ORIGIN_OR_DESTINATION_TEXT
 import com.aws.amazonlocation.TEST_WORD_SHYAMAL_CROSS_ROAD
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.waitForView
 import com.google.android.material.textfield.TextInputEditText
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -44,24 +45,17 @@ class RouteReverseBetweenFormToTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val cardDirectionTest =
                 onView(withId(R.id.card_direction)).check(matches(isDisplayed()))
             cardDirectionTest.perform(click())
 
-            Thread.sleep(DELAY_2000)
-
             val sourceEdt = waitForView(CoreMatchers.allOf(withId(R.id.edt_search_direction), isDisplayed()))
             sourceEdt?.perform(click())
-
-            Thread.sleep(DELAY_2000)
 
             val clMyLocation =
                 waitForView(CoreMatchers.allOf(withText(R.string.label_my_location), isDisplayed()))
             clMyLocation?.perform(click())
-
-            Thread.sleep(DELAY_2000)
 
             val destinationEdt = waitForView(
                 CoreMatchers.allOf(
@@ -70,8 +64,6 @@ class RouteReverseBetweenFormToTest : BaseTestMainActivity() {
                 ),
             )
             destinationEdt?.perform(click(), ViewActions.replaceText(TEST_WORD_SHYAMAL_CROSS_ROAD))
-
-            Thread.sleep(DELAY_2000)
 
             val suggestionListRv = waitForView(
                 CoreMatchers.allOf(
@@ -101,8 +93,6 @@ class RouteReverseBetweenFormToTest : BaseTestMainActivity() {
             lateinit var originText: String
             lateinit var destinationText: String
 
-            Thread.sleep(DELAY_3000)
-
             getInstrumentation().runOnMainSync {
                 val edtSearchDirection =
                     mActivityRule.activity.findViewById<TextInputEditText>(R.id.edt_search_direction)
@@ -120,8 +110,6 @@ class RouteReverseBetweenFormToTest : BaseTestMainActivity() {
             )
             swapBtn?.perform(click())
 
-            Thread.sleep(DELAY_3000)
-
             getInstrumentation().runOnMainSync {
                 val edtSearchDirection =
                     mActivityRule.activity.findViewById<TextInputEditText>(R.id.edt_search_direction)
@@ -132,8 +120,7 @@ class RouteReverseBetweenFormToTest : BaseTestMainActivity() {
                 Assert.assertTrue(TEST_FAILED_INVALID_ORIGIN_OR_DESTINATION_TEXT, originText == swappedDestinationText && destinationText == swappedOriginText)
             }
         } catch (e: Exception) {
-            failTest(133, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SearchAddressExactMatchPOICardLocationTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SearchAddressExactMatchPOICardLocationTest.kt
@@ -22,7 +22,6 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
@@ -31,7 +30,6 @@ import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_WORD_SHYAMAL_CROSS_ROAD
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.google.android.material.card.MaterialCardView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
@@ -41,7 +39,6 @@ import org.junit.Test
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class SearchAddressExactMatchPOICardLocationTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
@@ -49,15 +46,13 @@ class SearchAddressExactMatchPOICardLocationTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
-
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(matches(isDisplayed()))
             edtSearch.perform(click())
             onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_WORD_SHYAMAL_CROSS_ROAD))
             uiDevice.wait(
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion")),
-                DELAY_20000
+                DELAY_20000,
             )
             getInstrumentation().waitForIdleSync()
             val rvSearchPlaceSuggestion =
@@ -65,13 +60,19 @@ class SearchAddressExactMatchPOICardLocationTest : BaseTestMainActivity() {
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
                 rvSearchPlaceSuggestion.adapter?.itemCount?.let {
                     if (it >= 0) {
-                        Thread.sleep(DELAY_2000)
                         onView(withId(R.id.rv_search_places_suggestion))
                             .check(matches(hasDescendant(withText(TEST_WORD_SHYAMAL_CROSS_ROAD))))
-                        Thread.sleep(DELAY_2000)
+
                         onView(withId(R.id.rv_search_places_suggestion))
-                            .perform(RecyclerViewActions.actionOnItem<ViewHolder>(hasDescendant(withText(TEST_WORD_SHYAMAL_CROSS_ROAD)), click()))
-                        Thread.sleep(DELAY_2000)
+                            .perform(
+                                RecyclerViewActions.actionOnItem<ViewHolder>(
+                                    hasDescendant(
+                                        withText(TEST_WORD_SHYAMAL_CROSS_ROAD),
+                                    ),
+                                    click(),
+                                ),
+                            )
+
                         val btnDirection =
                             mActivityRule.activity.findViewById<MaterialCardView>(R.id.btn_direction)
                         if (btnDirection.visibility == View.VISIBLE) {
@@ -81,8 +82,10 @@ class SearchAddressExactMatchPOICardLocationTest : BaseTestMainActivity() {
                             )
                             val tvDirectionTime =
                                 mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_direction_distance)
-                            Thread.sleep(DELAY_2000)
-                            Assert.assertTrue(TEST_FAILED_DIRECTION_TIME_NOT_VISIBLE, tvDirectionTime.visibility == View.VISIBLE)
+                            Assert.assertTrue(
+                                TEST_FAILED_DIRECTION_TIME_NOT_VISIBLE,
+                                tvDirectionTime.visibility == View.VISIBLE,
+                            )
                         } else {
                             Assert.fail()
                         }
@@ -94,8 +97,7 @@ class SearchAddressExactMatchPOICardLocationTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(107, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SearchContactInfoPOICardTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SearchContactInfoPOICardTest.kt
@@ -4,7 +4,6 @@ import android.view.View
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
@@ -17,14 +16,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ALLOW
-import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
@@ -32,12 +26,8 @@ import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_FAILED_PLACE_LINK_NOT_VISIBLE
 import com.aws.amazonlocation.TEST_WORD_DOMINO_PIZZA
 import com.aws.amazonlocation.TEST_WORD_DOMINO_PIZZA_VEJALPUR
-import com.aws.amazonlocation.WHILE_USING_THE_APP
-import com.aws.amazonlocation.WHILE_USING_THE_APP_ALLOW
-import com.aws.amazonlocation.WHILE_USING_THE_APP_CAPS
+import com.aws.amazonlocation.checkLocationPermission
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.google.android.material.card.MaterialCardView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
@@ -47,33 +37,24 @@ import org.junit.Test
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class SearchContactInfoPOICardTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
     fun searchContactInfoPOICardTest() {
         try {
-            val btnContinueToApp = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/btn_continue_to_app"))
-            if (btnContinueToApp.exists()) {
-                btnContinueToApp.click()
-                Thread.sleep(DELAY_2000)
-            }
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
-            uiDevice.findObject(By.text(ALLOW))?.click()
-            Thread.sleep(DELAY_2000)
-            enableGPS(ApplicationProvider.getApplicationContext())
-            uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
+            checkLocationPermission(uiDevice)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(matches(isDisplayed()))
             edtSearch.perform(click())
-            onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_WORD_DOMINO_PIZZA_VEJALPUR))
+            onView(withId(R.id.edt_search_places)).perform(
+                replaceText(
+                    TEST_WORD_DOMINO_PIZZA_VEJALPUR,
+                ),
+            )
             uiDevice.wait(
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion")),
-                DELAY_20000
+                DELAY_20000,
             )
             getInstrumentation().waitForIdleSync()
             val rvSearchPlaceSuggestion =
@@ -81,13 +62,17 @@ class SearchContactInfoPOICardTest : BaseTestMainActivity() {
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
                 rvSearchPlaceSuggestion.adapter?.itemCount?.let {
                     if (it >= 0) {
-                        Thread.sleep(DELAY_2000)
                         onView(withId(R.id.rv_search_places_suggestion))
                             .check(matches(hasDescendant(withText(TEST_WORD_DOMINO_PIZZA))))
-                        Thread.sleep(DELAY_2000)
                         onView(withId(R.id.rv_search_places_suggestion))
-                            .perform(RecyclerViewActions.actionOnItem<ViewHolder>(hasDescendant(withText(TEST_WORD_DOMINO_PIZZA)), click()))
-                        Thread.sleep(DELAY_2000)
+                            .perform(
+                                RecyclerViewActions.actionOnItem<ViewHolder>(
+                                    hasDescendant(
+                                        withText(TEST_WORD_DOMINO_PIZZA),
+                                    ),
+                                    click(),
+                                ),
+                            )
                         val btnDirection =
                             mActivityRule.activity.findViewById<MaterialCardView>(R.id.btn_direction)
                         if (btnDirection.visibility == View.VISIBLE) {
@@ -97,8 +82,10 @@ class SearchContactInfoPOICardTest : BaseTestMainActivity() {
                             )
                             val tvPlaceLink =
                                 mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_place_link)
-                            Thread.sleep(DELAY_2000)
-                            Assert.assertTrue(TEST_FAILED_PLACE_LINK_NOT_VISIBLE, tvPlaceLink.visibility == View.VISIBLE)
+                            Assert.assertTrue(
+                                TEST_FAILED_PLACE_LINK_NOT_VISIBLE,
+                                tvPlaceLink.visibility == View.VISIBLE,
+                            )
                         } else {
                             Assert.fail()
                         }
@@ -110,8 +97,7 @@ class SearchContactInfoPOICardTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(107, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SearchPlaceDisplayedOnMapTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SearchPlaceDisplayedOnMapTest.kt
@@ -15,7 +15,6 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
@@ -42,7 +41,6 @@ class SearchPlaceDisplayedOnMapTest : BaseTestMainActivity() {
         var mapbox: MapLibreMap? = null
         enableGPS(ApplicationProvider.getApplicationContext())
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-        Thread.sleep(DELAY_1000)
 
         val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
         mapView.getMapAsync {

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SearchResultComparisonTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SearchResultComparisonTest.kt
@@ -13,7 +13,9 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -22,9 +24,7 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
-import com.aws.amazonlocation.DELAY_3000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
@@ -35,7 +35,6 @@ import com.aws.amazonlocation.TEST_FAILED_SEARCH_SHEET
 import com.aws.amazonlocation.TEST_WORD_RIO_TINTO
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.ui.main.explore.SearchPlacesAdapter
 import com.aws.amazonlocation.ui.main.explore.SearchPlacesSuggestionAdapter
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -49,7 +48,6 @@ import org.junit.Test
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class SearchResultComparisonTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
@@ -57,7 +55,6 @@ class SearchResultComparisonTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(matches(isDisplayed()))
@@ -65,7 +62,7 @@ class SearchResultComparisonTest : BaseTestMainActivity() {
             onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_WORD_RIO_TINTO))
             uiDevice.wait(
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion")),
-                DELAY_20000
+                DELAY_20000,
             )
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
@@ -81,13 +78,9 @@ class SearchResultComparisonTest : BaseTestMainActivity() {
                                 RecyclerViewActions.actionOnItemAtPosition<SearchPlacesSuggestionAdapter.SearchPlaceVH>(
                                     i,
                                     object : ViewAction {
-                                        override fun getConstraints(): Matcher<View> {
-                                            return isAssignableFrom(TextView::class.java)
-                                        }
+                                        override fun getConstraints(): Matcher<View> = isAssignableFrom(TextView::class.java)
 
-                                        override fun getDescription(): String {
-                                            return "Get data from RecyclerView item"
-                                        }
+                                        override fun getDescription(): String = "Get data from RecyclerView item"
 
                                         override fun perform(
                                             uiController: UiController?,
@@ -101,8 +94,6 @@ class SearchResultComparisonTest : BaseTestMainActivity() {
                                 ),
                             )
                         }
-
-                        Thread.sleep(DELAY_5000)
 
                         val clSearchSheet =
                             mActivityRule.activity.findViewById<ConstraintLayout>(R.id.bottom_sheet_search)
@@ -141,10 +132,8 @@ class SearchResultComparisonTest : BaseTestMainActivity() {
                                     Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion_direction")),
                                     DELAY_20000,
                                 )
-                                Thread.sleep(DELAY_3000)
                                 val rvSearchPlaceDirection =
                                     mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion_direction)
-                                Thread.sleep(DELAY_2000)
                                 if (rvSearchPlaceDirection.adapter?.itemCount != null) {
                                     val listInsideDataSearch = arrayListOf<String>()
                                     rvSearchPlaceDirection.adapter?.itemCount?.let { it1 ->
@@ -157,13 +146,10 @@ class SearchResultComparisonTest : BaseTestMainActivity() {
                                                     RecyclerViewActions.actionOnItemAtPosition<SearchPlacesAdapter.SearchPlaceVH>(
                                                         i,
                                                         object : ViewAction {
-                                                            override fun getConstraints(): Matcher<View> {
-                                                                return isAssignableFrom(TextView::class.java)
-                                                            }
+                                                            override fun getConstraints(): Matcher<View> =
+                                                                isAssignableFrom(TextView::class.java)
 
-                                                            override fun getDescription(): String {
-                                                                return "Get data from RecyclerView item"
-                                                            }
+                                                            override fun getDescription(): String = "Get data from RecyclerView item"
 
                                                             override fun perform(
                                                                 uiController: UiController?,
@@ -182,9 +168,10 @@ class SearchResultComparisonTest : BaseTestMainActivity() {
                                         }
                                     }
 
-                                    Thread.sleep(DELAY_3000)
-
-                                    Assert.assertTrue(TEST_FAILED_NOT_EQUAL, listDataSearch == listInsideDataSearch)
+                                    Assert.assertTrue(
+                                        TEST_FAILED_NOT_EQUAL,
+                                        listDataSearch == listInsideDataSearch,
+                                    )
                                 }
                             } else {
                                 Assert.fail(TEST_FAILED_DIRECTION_CARD)
@@ -200,8 +187,7 @@ class SearchResultComparisonTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(214, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingAWSDisconnectingTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingAWSDisconnectingTest.kt
@@ -15,8 +15,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_1000
-import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
@@ -44,7 +42,6 @@ class SettingAWSDisconnectingTest : BaseTestMainActivity() {
     fun delay() {
         val activity: MainActivity = mActivityRule.activity
         preferenceManager = (activity as BaseActivity).mPreferenceManager
-        Thread.sleep(DELAY_10000)
     }
 
     @Test
@@ -52,7 +49,6 @@ class SettingAWSDisconnectingTest : BaseTestMainActivity() {
         enableGPS(ApplicationProvider.getApplicationContext())
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
         val settingTabText = mActivityRule.activity.getString(R.string.menu_setting)
-        Thread.sleep(DELAY_1000)
         onView(
             AllOf.allOf(
                 withText(settingTabText),
@@ -60,7 +56,6 @@ class SettingAWSDisconnectingTest : BaseTestMainActivity() {
                 isDisplayed()
             )
         ).perform(ViewActions.click())
-        Thread.sleep(DELAY_1000)
         onView(
             AllOf.allOf(
                 withId(R.id.cl_aws_cloudformation),
@@ -68,29 +63,23 @@ class SettingAWSDisconnectingTest : BaseTestMainActivity() {
             )
         ).perform(ViewActions.click())
 
-        Thread.sleep(DELAY_1000)
-
         onView(withId(R.id.ns_cloud_formation)).perform(swipeUp())
-        Thread.sleep(DELAY_1000)
+
         val region =
             uiDevice.findObject(By.text("Canada (Central) ca-central-1"))
         region?.click()
 
-        Thread.sleep(DELAY_1000)
         val logOut =
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.disconnect_aws)))
         logOut?.click()
 
-        Thread.sleep(DELAY_1000)
         uiDevice.wait(
             Until.hasObject(By.text(mActivityRule.activity.getString(R.string.disconnect_aws))),
             DELAY_20000
         )
-        Thread.sleep(DELAY_1000)
         val disconnectAws =
             onView(withId(android.R.id.button1)).check(ViewAssertions.matches(isDisplayed()))
         disconnectAws.perform(ViewActions.click())
-        Thread.sleep(DELAY_1000)
 
         val poolId = preferenceManager.getValue(KEY_POOL_ID, "")
         Assert.assertTrue(TEST_FAILED_POOL_ID_NOT_BLANK, poolId == "")

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingRouteOptionAvailableTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingRouteOptionAvailableTest.kt
@@ -2,29 +2,18 @@ package com.aws.amazonlocation.ui.main
 
 import android.view.View
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ALLOW
-import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
-import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_ROUTE_OPTION_NOT_VISIBLE
-import com.aws.amazonlocation.WHILE_USING_THE_APP
-import com.aws.amazonlocation.WHILE_USING_THE_APP_CAPS
-import com.aws.amazonlocation.WHILE_USING_THE_APP_ALLOW
+import com.aws.amazonlocation.checkLocationPermission
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.junit.Assert
@@ -33,32 +22,16 @@ import org.junit.Test
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class SettingRouteOptionAvailableTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
     fun showSettingRouteOptionAvailableTest() {
         try {
-            Thread.sleep(DELAY_2000)
-            val btnContinueToApp = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/btn_continue_to_app"))
-            if (btnContinueToApp.exists()) {
-                btnContinueToApp.click()
-                Thread.sleep(DELAY_2000)
-            }
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
-            uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
-            uiDevice.findObject(By.text(ALLOW))?.click()
-            Thread.sleep(DELAY_2000)
-            enableGPS(ApplicationProvider.getApplicationContext())
-            uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
+            checkLocationPermission(uiDevice)
 
-            val explorer =
+            val settings =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_setting)))
-            explorer.click()
-
-            Thread.sleep(DELAY_1000)
+            settings.click()
 
             val defaultRouteOption =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_default_route_options)))
@@ -66,11 +39,11 @@ class SettingRouteOptionAvailableTest : BaseTestMainActivity() {
 
             uiDevice.wait(
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/tv_avoid_ferries")),
-                DELAY_20000
+                DELAY_20000,
             )
             uiDevice.wait(
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/tv_avoid_tools")),
-                DELAY_20000
+                DELAY_20000,
             )
 
             val tvAvoidFerries =
@@ -78,10 +51,12 @@ class SettingRouteOptionAvailableTest : BaseTestMainActivity() {
 
             val tvAvoidTools =
                 mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_avoid_tools)
-            Assert.assertTrue(TEST_FAILED_ROUTE_OPTION_NOT_VISIBLE, tvAvoidFerries.visibility == View.VISIBLE && tvAvoidTools.visibility == View.VISIBLE)
+            Assert.assertTrue(
+                TEST_FAILED_ROUTE_OPTION_NOT_VISIBLE,
+                tvAvoidFerries.visibility == View.VISIBLE && tvAvoidTools.visibility == View.VISIBLE,
+            )
         } catch (e: Exception) {
-            failTest(83, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingSignInTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingSignInTest.kt
@@ -3,11 +3,13 @@ package com.aws.amazonlocation.ui.main
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.view.isVisible
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
@@ -22,22 +24,18 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
-import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
 import com.aws.amazonlocation.DELAY_20000
-import com.aws.amazonlocation.DELAY_4000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED_LOGOUT_BUTTON_NOT_VISIBLE
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.core.AllOf
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
@@ -46,10 +44,6 @@ class SettingSignInTest : BaseTestMainActivity() {
 
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
-    @Before
-    fun delay() {
-        Thread.sleep(DELAY_10000)
-    }
 
     @Test
     fun showSettingSignInTest() {
@@ -57,7 +51,6 @@ class SettingSignInTest : BaseTestMainActivity() {
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
         val settingTabText = mActivityRule.activity.getString(R.string.menu_setting)
 
-        Thread.sleep(DELAY_1000)
         onView(
             AllOf.allOf(
                 withText(settingTabText),
@@ -66,7 +59,6 @@ class SettingSignInTest : BaseTestMainActivity() {
             ),
         ).perform(ViewActions.click())
 
-        Thread.sleep(DELAY_2000)
         onView(
             AllOf.allOf(
                 withId(R.id.cl_aws_cloudformation),
@@ -80,17 +72,16 @@ class SettingSignInTest : BaseTestMainActivity() {
             val appViews = UiScrollable(UiSelector().scrollable(true))
             appViews.scrollForward()
         }
-        Thread.sleep(DELAY_1000)
         val region =
             uiDevice.findObject(By.text("Canada (Central) ca-central-1"))
         region?.click()
 
-        Thread.sleep(DELAY_4000)
         val signIn =
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.sign_in)))
         signIn?.click()
 
-        Thread.sleep(DELAY_5000)
+        waitForView(allOf(withId(R.id.sign_in_web_view), isDisplayed()))
+
         onView(withId(R.id.sign_in_web_view))
             .check(matches(isDisplayed()))
 
@@ -113,7 +104,6 @@ class SettingSignInTest : BaseTestMainActivity() {
             Until.hasObject(By.text(mActivityRule.activity.getString(R.string.log_out))),
             DELAY_20000,
         )
-        Thread.sleep(DELAY_5000)
         val btnLogout =
             mActivityRule.activity.findViewById<AppCompatButton>(R.id.btn_logout)
         Assert.assertTrue(TEST_FAILED_LOGOUT_BUTTON_NOT_VISIBLE, btnLogout.isVisible)

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingSignOutTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingSignOutTest.kt
@@ -18,8 +18,6 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_1000
-import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
@@ -30,7 +28,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.hamcrest.core.AllOf
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
@@ -39,18 +36,12 @@ class SettingSignOutTest : BaseTestMainActivity() {
 
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
-    @Before
-    fun delay() {
-        Thread.sleep(DELAY_10000)
-    }
-
     @Test
     fun showSettingSignInTest() {
         enableGPS(ApplicationProvider.getApplicationContext())
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
         val settingTabText = mActivityRule.activity.getString(R.string.menu_setting)
 
-        Thread.sleep(DELAY_1000)
         Espresso.onView(
             AllOf.allOf(
                 withText(settingTabText),
@@ -59,7 +50,6 @@ class SettingSignOutTest : BaseTestMainActivity() {
             ),
         ).perform(ViewActions.click())
 
-        Thread.sleep(DELAY_1000)
         Espresso.onView(
             AllOf.allOf(
                 withId(R.id.cl_aws_cloudformation),
@@ -72,22 +62,19 @@ class SettingSignOutTest : BaseTestMainActivity() {
             val appViews = UiScrollable(UiSelector().scrollable(true))
             appViews.scrollForward()
         }
-        Thread.sleep(DELAY_1000)
+
         val region =
             uiDevice.findObject(By.text("Canada (Central) ca-central-1"))
         region?.click()
 
-        Thread.sleep(DELAY_1000)
         val logOut =
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.log_out)))
         logOut?.click()
 
-        Thread.sleep(DELAY_1000)
         uiDevice.wait(
             Until.hasObject(By.text(mActivityRule.activity.getString(R.string.logout))),
             DELAY_20000,
         )
-        Thread.sleep(DELAY_1000)
         val btnLogOut =
             Espresso.onView(withId(android.R.id.button1)).check(ViewAssertions.matches(isDisplayed()))
         btnLogOut.perform(ViewActions.click())
@@ -96,7 +83,6 @@ class SettingSignOutTest : BaseTestMainActivity() {
             Until.hasObject(By.text(mActivityRule.activity.getString(R.string.sign_in))),
             DELAY_20000,
         )
-        Thread.sleep(DELAY_1000)
         val btnSignIn =
             mActivityRule.activity.findViewById<AppCompatButton>(R.id.btn_sign_in)
         Assert.assertTrue(TEST_FAILED_SIGNIN_BUTTON_NOT_VISIBLE, btnSignIn.visibility == View.VISIBLE)

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsFragmentChangeLanguageTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsFragmentChangeLanguageTest.kt
@@ -12,13 +12,13 @@ import com.aws.amazonlocation.*
 import com.aws.amazonlocation.di.AppModule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers
 import org.hamcrest.core.AllOf.allOf
 import org.junit.*
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class SettingsFragmentChangeLanguageTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Throws(java.lang.Exception::class)
@@ -30,12 +30,10 @@ class SettingsFragmentChangeLanguageTest : BaseTestMainActivity() {
     fun checkChangeLanguage() {
         try {
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             goToLanguage()
         } catch (e: Exception) {
-            failTest(95, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
@@ -45,26 +43,22 @@ class SettingsFragmentChangeLanguageTest : BaseTestMainActivity() {
             allOf(
                 withText(settingTabText),
                 isDescendantOfA(withId(R.id.bottom_navigation_main)),
-                isDisplayed()
-            )
+                isDisplayed(),
+            ),
         ).perform(click())
-
-        Thread.sleep(DELAY_1000)
-
+        waitForView(CoreMatchers.allOf(withId(R.id.cl_language), isDisplayed()))
         onView(
             allOf(
                 withId(R.id.cl_language),
-                isDisplayed()
-            )
+                isDisplayed(),
+            ),
         ).perform(click())
-
-        Thread.sleep(DELAY_1000)
-
+        waitForView(CoreMatchers.allOf(withId(R.id.rb_arabic), isDisplayed()))
         onView(
             allOf(
                 withId(R.id.rb_arabic),
-                isDisplayed()
-            )
+                isDisplayed(),
+            ),
         ).perform(click())
 
         val rbArabic =

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsFragmentChangeRegionTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsFragmentChangeRegionTest.kt
@@ -27,7 +27,6 @@ import org.junit.*
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class SettingsFragmentChangeRegionTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Throws(java.lang.Exception::class)
@@ -39,12 +38,10 @@ class SettingsFragmentChangeRegionTest : BaseTestMainActivity() {
     fun checkChangeRegion() {
         try {
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             goToRegion()
         } catch (e: Exception) {
-            failTest(95, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 
@@ -54,63 +51,56 @@ class SettingsFragmentChangeRegionTest : BaseTestMainActivity() {
             allOf(
                 withText(settingTabText),
                 isDescendantOfA(withId(R.id.bottom_navigation_main)),
-                isDisplayed()
-            )
+                isDisplayed(),
+            ),
         ).perform(click())
 
-        Thread.sleep(DELAY_1000)
-
+        waitForView(CoreMatchers.allOf(withId(R.id.cl_region), isDisplayed()))
         onView(
             allOf(
                 withId(R.id.cl_region),
-                isDisplayed()
-            )
+                isDisplayed(),
+            ),
         ).perform(click())
 
-        Thread.sleep(DELAY_1000)
-
-        val listRv = waitForView(
-            CoreMatchers.allOf(
-                withId(R.id.rv_region),
-                isDisplayed(),
-                hasMinimumChildCount(1)
+        waitForView(CoreMatchers.allOf(withId(R.id.rv_region), isDisplayed()))
+        val listRv =
+            waitForView(
+                CoreMatchers.allOf(
+                    withId(R.id.rv_region),
+                    isDisplayed(),
+                    hasMinimumChildCount(1),
+                ),
             )
-        )
         listRv?.perform(
             RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
                 2,
-                click()
-            )
+                click(),
+            ),
         )
         var rbRegionIsChecked = false
-        Thread.sleep(DELAY_1000)
         onView(withId(R.id.rv_region)).perform(
             RecyclerViewActions.scrollToPosition<RegionAdapter.RegionVH>(
-                2
+                2,
             ),
             RecyclerViewActions.actionOnItemAtPosition<RegionAdapter.RegionVH>(
                 2,
                 object : ViewAction {
-                    override fun getConstraints(): Matcher<View> {
-                        return isAssignableFrom(TextView::class.java)
-                    }
+                    override fun getConstraints(): Matcher<View> = isAssignableFrom(TextView::class.java)
 
-                    override fun getDescription(): String {
-                        return "Get data from RecyclerView item"
-                    }
+                    override fun getDescription(): String = "Get data from RecyclerView item"
 
                     override fun perform(
                         uiController: UiController?,
-                        view: View
+                        view: View,
                     ) {
                         val rbRegion =
                             view.findViewById<AppCompatRadioButton>(R.id.rb_region)
                         rbRegionIsChecked = rbRegion.isSelected
                     }
-                }
-            )
+                },
+            ),
         )
-        Thread.sleep(DELAY_1000)
         Assert.assertTrue(TEST_FAILED, rbRegionIsChecked)
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsFragmentContentTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsFragmentContentTest.kt
@@ -6,27 +6,21 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.rule.ActivityTestRule
-import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.*
 import com.aws.amazonlocation.di.AppModule
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.hamcrest.core.AllOf.allOf
 import org.junit.Assert
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class SettingsFragmentContentTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     private lateinit var bottomNavigation: BottomNavigationView
@@ -42,7 +36,6 @@ class SettingsFragmentContentTest : BaseTestMainActivity() {
     fun checkContent() {
         try {
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val settingsTabText = mActivityRule.activity.getString(R.string.menu_setting)
 
@@ -50,27 +43,25 @@ class SettingsFragmentContentTest : BaseTestMainActivity() {
                 allOf(
                     withText(settingsTabText),
                     isDescendantOfA(withId(R.id.bottom_navigation_main)),
-                    isDisplayed()
-                )
-            )
-                .perform(click())
-
-            Thread.sleep(DELAY_1000)
+                    isDisplayed(),
+                ),
+            ).perform(click())
 
             if (!bottomNavigation.menu.findItem(R.id.menu_settings).isChecked) {
                 Assert.fail(TEST_FAILED_NAVIGATION_TAB_SETTINGS_NOT_SELECTED)
             }
 
             val mapStyle = mActivityRule.activity.findViewById<ConstraintLayout>(R.id.cl_map_style)
-            val defaultRoute = mActivityRule.activity.findViewById<ConstraintLayout>(R.id.cl_route_option)
-            val connectToAws = mActivityRule.activity.findViewById<ConstraintLayout>(R.id.cl_aws_cloudformation)
+            val defaultRoute =
+                mActivityRule.activity.findViewById<ConstraintLayout>(R.id.cl_route_option)
+            val connectToAws =
+                mActivityRule.activity.findViewById<ConstraintLayout>(R.id.cl_aws_cloudformation)
 
             if (!mapStyle.isVisible || !defaultRoute.isVisible || !connectToAws.isVisible) {
                 Assert.fail(TEST_FAILED_SETTINGS_ALL_OPTIONS_NOT_VISIBLE)
             }
         } catch (e: Exception) {
-            failTest(85, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsFragmentDefaultRouteTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsFragmentDefaultRouteTest.kt
@@ -27,7 +27,6 @@ import org.junit.*
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class SettingsFragmentDefaultRouteTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Throws(java.lang.Exception::class)
@@ -46,14 +45,16 @@ class SettingsFragmentDefaultRouteTest : BaseTestMainActivity() {
     fun checkDefaultRouteOptionsTest() {
         try {
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             goToDefaultRouteSettings()
 
             toggleSwitch(R.id.switch_avoid_tools)
             toggleSwitch(R.id.switch_avoid_ferries)
 
-            checkDefaultRouteOptions(avoidTollsShouldBe = true, avoidFerriesShouldBe = true)
+            checkDefaultRouteOptions(
+                avoidTollsShouldBe = true,
+                avoidFerriesShouldBe = true
+            )
         } catch (_: Exception) {
             Assert.fail(TEST_FAILED)
         }
@@ -71,16 +72,19 @@ class SettingsFragmentDefaultRouteTest : BaseTestMainActivity() {
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_setting)))
         explorer.click()
 
-        val routeOptions = waitForView(
-            allOf(
-                withId(R.id.cl_route_option),
-                isDisplayed(),
-            ),
-        )
+        val routeOptions =
+            waitForView(
+                allOf(
+                    withId(R.id.cl_route_option),
+                    isDisplayed(),
+                ),
+            )
         routeOptions?.perform(click())
     }
 
-    private fun toggleSwitch(@IdRes switchId: Int) {
+    private fun toggleSwitch(
+        @IdRes switchId: Int,
+    ) {
         waitForView(
             allOf(
                 withId(switchId),
@@ -89,32 +93,32 @@ class SettingsFragmentDefaultRouteTest : BaseTestMainActivity() {
         )?.perform(click())
     }
 
-    private fun checkDefaultRouteOptions(avoidTollsShouldBe: Boolean, avoidFerriesShouldBe: Boolean) {
+    private fun checkDefaultRouteOptions(
+        avoidTollsShouldBe: Boolean,
+        avoidFerriesShouldBe: Boolean
+    ) {
         val explorer =
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_explore)))
         explorer.click()
 
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-        Thread.sleep(DELAY_2000)
 
         val cardDirectionTest =
             onView(withId(R.id.card_direction)).check(ViewAssertions.matches(isDisplayed()))
         cardDirectionTest.perform(click())
 
-        Thread.sleep(DELAY_2000)
-
-        val sourceEdt = waitForView(CoreMatchers.allOf(withId(R.id.edt_search_direction), isDisplayed()))
+        val sourceEdt =
+            waitForView(CoreMatchers.allOf(withId(R.id.edt_search_direction), isDisplayed()))
         sourceEdt?.perform(replaceText(SEARCH_TEST_WORD_1))
 
-        Thread.sleep(DELAY_2000)
-
-        val suggestionListSrcRv = waitForView(
-            CoreMatchers.allOf(
-                withId(R.id.rv_search_places_suggestion_direction),
-                isDisplayed(),
-                hasMinimumChildCount(1),
-            ),
-        )
+        val suggestionListSrcRv =
+            waitForView(
+                CoreMatchers.allOf(
+                    withId(R.id.rv_search_places_suggestion_direction),
+                    isDisplayed(),
+                    hasMinimumChildCount(1),
+                ),
+            )
         suggestionListSrcRv?.perform(
             RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
                 0,
@@ -122,26 +126,24 @@ class SettingsFragmentDefaultRouteTest : BaseTestMainActivity() {
             ),
         )
 
-        Thread.sleep(DELAY_2000)
-
-        val destinationEdt = waitForView(
-            CoreMatchers.allOf(
-                withId(R.id.edt_search_dest),
-                isDisplayed(),
-            ),
-        )
+        val destinationEdt =
+            waitForView(
+                CoreMatchers.allOf(
+                    withId(R.id.edt_search_dest),
+                    isDisplayed(),
+                ),
+            )
         destinationEdt?.perform(click())
         destinationEdt?.perform(typeText(SEARCH_TEST_WORD_2))
 
-        Thread.sleep(DELAY_2000)
-
-        val suggestionListDestRv = waitForView(
-            CoreMatchers.allOf(
-                withId(R.id.rv_search_places_suggestion_direction),
-                isDisplayed(),
-                hasMinimumChildCount(1),
-            ),
-        )
+        val suggestionListDestRv =
+            waitForView(
+                CoreMatchers.allOf(
+                    withId(R.id.rv_search_places_suggestion_direction),
+                    isDisplayed(),
+                    hasMinimumChildCount(1),
+                ),
+            )
         suggestionListDestRv?.perform(
             RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
                 0,
@@ -156,22 +158,24 @@ class SettingsFragmentDefaultRouteTest : BaseTestMainActivity() {
             ),
         )
 
-        val cardRoutingOption = waitForView(
-            CoreMatchers.allOf(
-                withId(R.id.card_routing_option),
-                withEffectiveVisibility(Visibility.VISIBLE),
-            ),
-        )
+        val cardRoutingOption =
+            waitForView(
+                CoreMatchers.allOf(
+                    withId(R.id.card_routing_option),
+                    withEffectiveVisibility(Visibility.VISIBLE),
+                ),
+            )
         cardRoutingOption?.perform(click())
-
-        Thread.sleep(DELAY_2000)
 
         getInstrumentation().waitForIdleSync()
         getInstrumentation().runOnMainSync {
-            val switchAvoidToll = mActivityRule.activity.findViewById<SwitchCompat>(R.id.switch_avoid_tools)
-            val switchAvoidFerry = mActivityRule.activity.findViewById<SwitchCompat>(R.id.switch_avoid_ferries)
-
-            if (switchAvoidToll.isChecked != avoidTollsShouldBe || switchAvoidFerry.isChecked != avoidFerriesShouldBe) {
+            val switchAvoidToll =
+                mActivityRule.activity.findViewById<SwitchCompat>(R.id.switch_avoid_tools)
+            val switchAvoidFerry =
+                mActivityRule.activity.findViewById<SwitchCompat>(R.id.switch_avoid_ferries)
+            if (switchAvoidToll.isChecked != avoidTollsShouldBe ||
+                switchAvoidFerry.isChecked != avoidFerriesShouldBe
+            ) {
                 Assert.fail(TEST_FAILED_DEFAULT_ROUTE_OPTIONS_NOT_LOADED)
             }
         }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsMapPoliticalViewTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SettingsMapPoliticalViewTest.kt
@@ -39,10 +39,7 @@ class SettingsMapPoliticalViewTest : BaseTestMainActivity() {
 
     @Test
     fun testSettingsMapPoliticalViewTest() {
-        Thread.sleep(DELAY_2000)
-
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-        Thread.sleep(DELAY_2000)
 
         goToMapStyles()
 
@@ -50,22 +47,16 @@ class SettingsMapPoliticalViewTest : BaseTestMainActivity() {
             onView(withId(R.id.cl_political_view)).check(matches(isDisplayed()))
         clPoliticalView.perform(click())
 
-        Thread.sleep(DELAY_2000)
-
         val etSearchCountry =
             onView(withId(R.id.et_search_country)).check(matches(isDisplayed()))
         etSearchCountry.perform(click())
-
-        Thread.sleep(DELAY_1000)
         onView(withId(R.id.et_search_country)).perform(replaceText(TEST_WORD_RUS))
 
-        Thread.sleep(DELAY_1000)
+        uiDevice.wait(Until.hasObject(By.text(mActivityRule.activity.getString(R.string.description_rus))), DELAY_5000)
 
         val rbCountry =
             onView(withId(R.id.rb_country)).check(matches(isDisplayed()))
         rbCountry.perform(click())
-
-        Thread.sleep(DELAY_2000)
 
         val tvPoliticalDescription = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/tv_political_description"))
         Assert.assertTrue(TEST_FAILED_COUNTRY, tvPoliticalDescription.text.contains(TEST_WORD_RUS))
@@ -81,8 +72,6 @@ class SettingsMapPoliticalViewTest : BaseTestMainActivity() {
         )
             ?.perform(click())
 
-        Thread.sleep(DELAY_3000)
-
         waitForView(
             AllOf.allOf(
                 withId(R.id.cl_map_style),
@@ -90,7 +79,5 @@ class SettingsMapPoliticalViewTest : BaseTestMainActivity() {
             )
         )
             ?.perform(click())
-
-        Thread.sleep(DELAY_3000)
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SimulationStartTrackingHistoryLoggedTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SimulationStartTrackingHistoryLoggedTest.kt
@@ -5,7 +5,9 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -14,16 +16,16 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_TRACKING_HISTORY
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
+import com.aws.amazonlocation.waitForView
 import com.google.android.material.card.MaterialCardView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -38,8 +40,6 @@ class SimulationStartTrackingHistoryLoggedTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
-
             val tracking =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
             tracking.click()
@@ -58,7 +58,6 @@ class SimulationStartTrackingHistoryLoggedTest : BaseTestMainActivity() {
                     btnTryTracker.performClick()
                 }
             }
-            Thread.sleep(DELAY_2000)
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_start_simulation))),
                 DELAY_1000
@@ -67,20 +66,18 @@ class SimulationStartTrackingHistoryLoggedTest : BaseTestMainActivity() {
             val labelStartSimulation =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_start_simulation)))
             labelStartSimulation.click()
-            Thread.sleep(DELAY_5000)
             swipeUp()
 
-            Thread.sleep(DELAY_2000)
             val rvTrackingSimulation =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_tracking_simulation)
             val itemCount = rvTrackingSimulation.adapter?.itemCount ?: 0
-            Thread.sleep(DELAY_5000)
+
             val ivBackArrowChangeRoute =
                 mActivityRule.activity.findViewById<AppCompatImageView>(R.id.iv_back_arrow_change_route)
             mActivityRule.activity.runOnUiThread {
                 ivBackArrowChangeRoute.performClick()
             }
-            Thread.sleep(DELAY_5000)
+            waitForView(allOf(withId(R.id.rv_tracking_simulation), isDisplayed(), hasMinimumChildCount(1)))
             if (rvTrackingSimulation.adapter?.itemCount != null) {
                 rvTrackingSimulation.adapter?.itemCount?.let {
                     Assert.assertTrue(TEST_FAILED_NO_TRACKING_HISTORY, it > itemCount)

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SimulationStopTrackingHistoryLoggedTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/SimulationStopTrackingHistoryLoggedTest.kt
@@ -6,10 +6,9 @@ import androidx.appcompat.widget.AppCompatSpinner
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso.onData
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.matcher.RootMatchers.isPlatformPopup
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -18,19 +17,17 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
-import com.aws.amazonlocation.DELAY_3000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_TRACKING_HISTORY
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
 import com.aws.amazonlocation.utils.notificationData
+import com.aws.amazonlocation.waitForView
 import com.google.android.material.card.MaterialCardView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import org.hamcrest.CoreMatchers.anything
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -45,7 +42,6 @@ class SimulationStopTrackingHistoryLoggedTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val tracking =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
@@ -65,7 +61,6 @@ class SimulationStopTrackingHistoryLoggedTest : BaseTestMainActivity() {
                     btnTryTracker.performClick()
                 }
             }
-            Thread.sleep(DELAY_2000)
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_start_simulation))),
                 DELAY_1000
@@ -74,19 +69,16 @@ class SimulationStopTrackingHistoryLoggedTest : BaseTestMainActivity() {
             val labelStartSimulation =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_start_simulation)))
             labelStartSimulation.click()
-            Thread.sleep(DELAY_5000)
             swipeUp()
 
-            Thread.sleep(DELAY_2000)
             val rvTrackingSimulation =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_tracking_simulation)
-            Thread.sleep(DELAY_3000)
+
             val ivBackArrowChangeRoute =
                 mActivityRule.activity.findViewById<AppCompatImageView>(R.id.iv_back_arrow_change_route)
             mActivityRule.activity.runOnUiThread {
                 ivBackArrowChangeRoute.performClick()
             }
-            Thread.sleep(DELAY_2000)
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_stop_tracking))),
                 DELAY_1000
@@ -104,7 +96,6 @@ class SimulationStopTrackingHistoryLoggedTest : BaseTestMainActivity() {
                 spinnerChangeBus.performClick()
             }
 
-            Thread.sleep(DELAY_1000)
             val data =
                 uiDevice.findObject(By.text(notificationData[2].name))
 
@@ -112,9 +103,7 @@ class SimulationStopTrackingHistoryLoggedTest : BaseTestMainActivity() {
             mActivityRule.activity.runOnUiThread {
                 ivBackArrowChangeRoute.performClick()
             }
-
-            Thread.sleep(DELAY_2000)
-
+            waitForView(allOf(withId(R.id.rv_tracking_simulation), isDisplayed(), hasMinimumChildCount(1)))
             if (rvTrackingSimulation.adapter?.itemCount != null) {
                 rvTrackingSimulation.adapter?.itemCount?.let {
                     Assert.assertTrue(TEST_FAILED_NO_TRACKING_HISTORY, it == 0)

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingAwsConnectTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingAwsConnectTest.kt
@@ -3,7 +3,6 @@ package com.aws.amazonlocation.ui.main
 import android.content.Context
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
@@ -14,41 +13,27 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import com.aws.amazonlocation.ALLOW
-import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_1000
-import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
-import com.aws.amazonlocation.DELAY_4000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_INVALID_IDENTITY_POOL_ID
-import com.aws.amazonlocation.TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED
-import com.aws.amazonlocation.WHILE_USING_THE_APP
-import com.aws.amazonlocation.WHILE_USING_THE_APP_CAPS
-import com.aws.amazonlocation.WHILE_USING_THE_APP_ALLOW
+import com.aws.amazonlocation.checkLocationPermission
 import com.aws.amazonlocation.di.AppModule
-import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.scrollForView
 import com.aws.amazonlocation.utils.KEY_POOL_ID
 import com.aws.amazonlocation.utils.PreferenceManager
-import com.aws.amazonlocation.waitUntil
+import com.aws.amazonlocation.waitForView
 import com.google.android.material.card.MaterialCardView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
-import org.maplibre.android.maps.MapLibreMap
-import org.maplibre.android.maps.MapView
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
@@ -59,38 +44,7 @@ class TrackingAwsConnectTest : BaseTestMainActivity() {
     @Test
     fun showAwsConnectTest() {
         try {
-            Thread.sleep(DELAY_4000)
-            enableGPS(ApplicationProvider.getApplicationContext())
-            val btnContinueToApp = uiDevice.findObject(UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/btn_continue_to_app"))
-            if (btnContinueToApp.exists()) {
-                btnContinueToApp.click()
-                Thread.sleep(DELAY_2000)
-                try {
-                    Thread.sleep(DELAY_2000)
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP))?.click()
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP_CAPS))?.click()
-                    uiDevice.findObject(By.text(WHILE_USING_THE_APP_ALLOW))?.click()
-                    uiDevice.findObject(By.text(ALLOW))?.click()
-                    Thread.sleep(DELAY_2000)
-                    enableGPS(ApplicationProvider.getApplicationContext())
-                    uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-                    var mapbox: MapLibreMap? = null
-                    val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
-                    mapView.getMapAsync {
-                        mapbox = it
-                    }
-                    Thread.sleep(DELAY_4000)
-                    waitUntil(DELAY_5000, 25) {
-                        mapbox?.locationComponent?.isLocationComponentActivated == true && mapbox?.locationComponent?.isLocationComponentEnabled == true
-                    }
-                    Assert.assertTrue(TEST_FAILED_LOCATION_COMPONENT_NOT_ACTIVATED_OR_ENABLED, mapbox?.locationComponent?.isLocationComponentActivated == true && mapbox?.locationComponent?.isLocationComponentEnabled == true)
-                } catch (e: UiObjectNotFoundException) {
-                    failTest(67, e)
-                    Assert.fail(TEST_FAILED)
-                }
-            }
-            uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
+            checkLocationPermission(uiDevice)
 
             val tracking =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
@@ -110,7 +64,7 @@ class TrackingAwsConnectTest : BaseTestMainActivity() {
                     btnTryTracker.performClick()
                 }
             }
-            Thread.sleep(DELAY_1000)
+            waitForView(allOf(withId(R.id.edt_identity_pool_id), isDisplayed()))
             val appViews = UiScrollable(UiSelector().scrollable(true))
 
             val edtIdentityPoolId =
@@ -151,11 +105,8 @@ class TrackingAwsConnectTest : BaseTestMainActivity() {
             val btnConnect =
                 onView(withId(R.id.btn_connect)).check(ViewAssertions.matches(isDisplayed()))
             btnConnect.perform(click())
-            Thread.sleep(DELAY_5000)
-//            uiDevice.wait(
-//                Until.hasObject(By.text(mActivityRule.activity.getString(R.string.you_are_connected))),
-//                DELAY_5000,
-//            )
+
+            waitForView(allOf(withId(R.id.tv_sign_in_required), isDisplayed()))
             val targetContext: Context = getInstrumentation().targetContext.applicationContext
             val pm = PreferenceManager(targetContext)
             val mPoolId = pm.getValue(KEY_POOL_ID, "")
@@ -164,8 +115,7 @@ class TrackingAwsConnectTest : BaseTestMainActivity() {
                 mPoolId == BuildConfig.IDENTITY_POOL_ID,
             )
         } catch (e: Exception) {
-            failTest(90, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingDeleteTrackingHistoryTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingDeleteTrackingHistoryTest.kt
@@ -5,6 +5,9 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -14,47 +17,45 @@ import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_COUNT_NOT_ZERO
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class TrackingDeleteTrackingHistoryTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
     fun showDeleteTrackingTest() {
         enableGPS(ApplicationProvider.getApplicationContext())
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-        Thread.sleep(DELAY_1000)
 
-        val tracking = uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
+        val tracking =
+            uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
         tracking.click()
 
-        Thread.sleep(DELAY_5000)
         uiDevice.wait(
             Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking))),
-            DELAY_1000
+            DELAY_1000,
         )
         val labelStartTracking =
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking)))
         labelStartTracking?.click()
 
-        Thread.sleep(DELAY_15000)
+        waitForView(allOf(withId(R.id.rv_tracking), isDisplayed(), hasMinimumChildCount(1)))
         uiDevice.wait(
             Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_stop_tracking))),
-            DELAY_1000
+            DELAY_1000,
         )
         val labelStopTracking =
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_stop_tracking)))
@@ -75,16 +76,16 @@ class TrackingDeleteTrackingHistoryTest : BaseTestMainActivity() {
         if (tvDeleteTrackingData.visibility == View.VISIBLE) {
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_delete_tracking_data))),
-                DELAY_1000
+                DELAY_1000,
             )
 
             val labelDeleteTrackingData =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_delete_tracking_data)))
             labelDeleteTrackingData?.click()
-            Thread.sleep(DELAY_1000)
+
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.ok))),
-                DELAY_1000
+                DELAY_1000,
             )
 
             val labelOk =
@@ -92,7 +93,7 @@ class TrackingDeleteTrackingHistoryTest : BaseTestMainActivity() {
             labelOk?.click()
             uiDevice.wait(
                 Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/layout_no_data_found")),
-                DELAY_1000
+                DELAY_1000,
             )
             val rvTracking =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_tracking)
@@ -100,7 +101,6 @@ class TrackingDeleteTrackingHistoryTest : BaseTestMainActivity() {
 
             Assert.assertTrue(TEST_FAILED_COUNT_NOT_ZERO, itemCount == 0)
         } else {
-            failTest(143, null)
             Assert.fail(TEST_FAILED)
         }
     }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingGeofenceEnterTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingGeofenceEnterTest.kt
@@ -16,7 +16,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_3000
 import com.aws.amazonlocation.DELAY_5000
@@ -51,14 +50,12 @@ class TrackingGeofenceEnterTest : BaseTestMainActivity() {
     fun showTrackingGeofenceEnterTest() {
         enableGPS(ApplicationProvider.getApplicationContext())
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-        Thread.sleep(DELAY_1000)
 
         val tracking = uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
         tracking.click()
-        Thread.sleep(DELAY_5000)
         uiDevice.wait(
             Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking))),
-            DELAY_1000
+            DELAY_5000
         )
         val labelStartTracking =
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking)))

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingGeofenceExitTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingGeofenceExitTest.kt
@@ -15,7 +15,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
@@ -26,7 +25,6 @@ import com.aws.amazonlocation.TRACKING_ENTERED
 import com.aws.amazonlocation.TRACKING_EXITED
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import org.hamcrest.CoreMatchers.allOf
@@ -45,15 +43,12 @@ class TrackingGeofenceExitTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val tracking = uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
             tracking.click()
-
-            Thread.sleep(DELAY_5000)
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking))),
-                DELAY_1000
+                DELAY_5000
             )
             val labelStartTracking =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking)))
@@ -68,7 +63,6 @@ class TrackingGeofenceExitTest : BaseTestMainActivity() {
                 val labelOk =
                     uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.ok)))
                 labelOk?.click()
-                Thread.sleep(DELAY_1000)
 
                 uiDevice.wait(
                     Until.hasObject(By.text(mActivityRule.activity.getString(R.string.ok))),
@@ -79,12 +73,10 @@ class TrackingGeofenceExitTest : BaseTestMainActivity() {
             } else if (dialogText.contains(TRACKING_EXITED)) {
                 Assert.assertTrue(TEST_FAILED_NOT_TRACKING_EXIT_DIALOG, dialogText.contains(TRACKING_EXITED))
             } else {
-                failTest(119, null)
                 Assert.fail(TEST_FAILED)
             }
         } catch (e: Exception) {
-            failTest(123, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingSignInTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingSignInTest.kt
@@ -17,17 +17,15 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
-import com.aws.amazonlocation.DELAY_1000
-import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_20000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import org.junit.Before
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
@@ -36,23 +34,20 @@ class TrackingSignInTest : BaseTestMainActivity() {
 
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
-    @Before
-    fun delay() {
-        Thread.sleep(DELAY_10000)
-    }
-
     @Test
     fun showSignInTest() {
         enableGPS(ApplicationProvider.getApplicationContext())
         uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-        Thread.sleep(DELAY_10000)
+
         val tracking = uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
         tracking.click()
-        Thread.sleep(DELAY_1000)
+
         val signIn =
             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.sign_in)))
         signIn?.click()
-        Thread.sleep(DELAY_5000)
+
+        waitForView(allOf(withId(R.id.sign_in_web_view), isDisplayed()))
+
         onView(withId(R.id.sign_in_web_view))
             .check(matches(isDisplayed()))
 

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingStartTrackingHistoryLoggedTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingStartTrackingHistoryLoggedTest.kt
@@ -2,6 +2,9 @@ package com.aws.amazonlocation.ui.main
 
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -10,16 +13,15 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_20000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_TRACKING_HISTORY
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -34,15 +36,14 @@ class TrackingStartTrackingHistoryLoggedTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val tracking = uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
             tracking.click()
 
-            Thread.sleep(DELAY_5000)
             val rvTracking =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_tracking)
             val itemCount = rvTracking.adapter?.itemCount ?: 0
+
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking))),
                 DELAY_1000
@@ -51,7 +52,8 @@ class TrackingStartTrackingHistoryLoggedTest : BaseTestMainActivity() {
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking)))
             labelStartTracking?.click()
 
-            Thread.sleep(DELAY_20000)
+            waitForView(allOf(withId(R.id.rv_tracking), isDisplayed(), hasMinimumChildCount(1)))
+
             if (rvTracking.adapter?.itemCount != null) {
                 rvTracking.adapter?.itemCount?.let {
                     Assert.assertTrue(TEST_FAILED_NO_TRACKING_HISTORY, itemCount < it)
@@ -60,8 +62,7 @@ class TrackingStartTrackingHistoryLoggedTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_TRACKING_HISTORY)
             }
         } catch (e: Exception) {
-            failTest(105, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingStartTrackingMapDisplayTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingStartTrackingMapDisplayTest.kt
@@ -3,6 +3,9 @@ package com.aws.amazonlocation.ui.main
 import android.location.Location
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -11,21 +14,20 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.DELAY_3000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_IMAGE_NULL
 import com.aws.amazonlocation.TEST_FAILED_NO_TRACKING_HISTORY
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
 import com.aws.amazonlocation.mockLocationsExit
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 import org.maplibre.android.camera.CameraUpdateFactory
@@ -46,7 +48,6 @@ class TrackingStartTrackingMapDisplayTest : BaseTestMainActivity() {
             var mapbox: MapLibreMap? = null
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
             val mapView = mActivityRule.activity.findViewById<MapView>(R.id.mapView)
             mapView.getMapAsync {
@@ -55,7 +56,7 @@ class TrackingStartTrackingMapDisplayTest : BaseTestMainActivity() {
             val tracking = uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
             tracking.click()
 
-            Thread.sleep(DELAY_5000)
+            waitForView(allOf(withId(R.id.rv_tracking), isDisplayed()))
             val rvTracking =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_tracking)
             val itemCount = rvTracking.adapter?.itemCount ?: 0
@@ -114,7 +115,7 @@ class TrackingStartTrackingMapDisplayTest : BaseTestMainActivity() {
                     latLng
                 )
             }
-            Thread.sleep(DELAY_20000)
+            waitForView(allOf(withId(R.id.rv_tracking), isDisplayed(), hasMinimumChildCount(itemCount+1)))
             if (rvTracking.adapter?.itemCount != null) {
                 rvTracking.adapter?.itemCount?.let {
                     if (itemCount < it) {
@@ -131,8 +132,7 @@ class TrackingStartTrackingMapDisplayTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_TRACKING_HISTORY)
             }
         } catch (e: Exception) {
-            failTest(175, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingStartTrackingTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingStartTrackingTest.kt
@@ -2,32 +2,33 @@ package com.aws.amazonlocation.ui.main
 
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.DELAY_1000
 import com.aws.amazonlocation.DELAY_15000
 import com.aws.amazonlocation.DELAY_20000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_TRACKING_HISTORY
 import com.aws.amazonlocation.TEST_FAILED_NO_TRACKING_HISTORY_NULL
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class TrackingStartTrackingTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
@@ -35,26 +36,22 @@ class TrackingStartTrackingTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
-            val tracking = uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
+            val tracking =
+                uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
             tracking.click()
-            Thread.sleep(DELAY_5000)
 
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking))),
-                DELAY_20000
+                DELAY_20000,
             )
             val labelStartTracking =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking)))
             labelStartTracking?.click()
 
-            Thread.sleep(DELAY_20000)
-
+            waitForView(allOf(withId(R.id.rv_tracking), isDisplayed(), hasMinimumChildCount(1)))
             val rvTracking =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_tracking)
-
-            Thread.sleep(3000)
 
             if (rvTracking.adapter?.itemCount != null) {
                 rvTracking.adapter?.itemCount?.let {
@@ -64,8 +61,7 @@ class TrackingStartTrackingTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_TRACKING_HISTORY_NULL)
             }
         } catch (e: Exception) {
-            failTest(93, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingStopTrackingTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/TrackingStopTrackingTest.kt
@@ -2,6 +2,9 @@ package com.aws.amazonlocation.ui.main
 
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -9,26 +12,23 @@ import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.DELAY_1000
-import com.aws.amazonlocation.DELAY_10000
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_20000
-import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
 import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_TRACKING_HISTORY
 import com.aws.amazonlocation.TEST_FAILED_NO_UPDATE_TRACKING_HISTORY
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class TrackingStopTrackingTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
@@ -36,29 +36,31 @@ class TrackingStopTrackingTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_1000)
 
-            val tracking = uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
+            val tracking =
+                uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.menu_tracking)))
             tracking.click()
-            Thread.sleep(DELAY_5000)
+
+            waitForView(allOf(withId(R.id.rv_tracking), isDisplayed()))
             val rvTracking =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_tracking)
             var itemCount = rvTracking.adapter?.itemCount ?: 0
             uiDevice.wait(
                 Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking))),
-                DELAY_1000
+                DELAY_1000,
             )
             val labelStartTracking =
                 uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_start_tracking)))
             labelStartTracking?.click()
 
-            Thread.sleep(DELAY_20000)
+            waitForView(allOf(withId(R.id.rv_tracking), isDisplayed(), hasMinimumChildCount(1)))
+
             if (rvTracking.adapter?.itemCount != null) {
                 rvTracking.adapter?.itemCount?.let {
                     if (itemCount <= it) {
                         uiDevice.wait(
                             Until.hasObject(By.text(mActivityRule.activity.getString(R.string.label_stop_tracking))),
-                            DELAY_1000
+                            DELAY_1000,
                         )
                         val labelStopTracking =
                             uiDevice.findObject(By.text(mActivityRule.activity.getString(R.string.label_stop_tracking)))
@@ -66,9 +68,11 @@ class TrackingStopTrackingTest : BaseTestMainActivity() {
                         rvTracking.adapter?.itemCount?.let { it1 ->
                             itemCount = it1
                         }
-                        Thread.sleep(DELAY_10000)
                         rvTracking.adapter?.itemCount?.let { it1 ->
-                            Assert.assertTrue(TEST_FAILED_NO_UPDATE_TRACKING_HISTORY, itemCount == it1)
+                            Assert.assertTrue(
+                                TEST_FAILED_NO_UPDATE_TRACKING_HISTORY,
+                                itemCount == it1,
+                            )
                         }
                     } else {
                         Assert.fail(TEST_FAILED_NO_TRACKING_HISTORY)
@@ -78,8 +82,7 @@ class TrackingStopTrackingTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_TRACKING_HISTORY)
             }
         } catch (e: Exception) {
-            failTest(124, e)
-            Assert.fail(TEST_FAILED)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/bug/AfterSearchDirectionErrorExistsTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/bug/AfterSearchDirectionErrorExistsTest.kt
@@ -9,7 +9,9 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -18,26 +20,25 @@ import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
 import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
-import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.DELAY_5000
 import com.aws.amazonlocation.R
+import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_DATA_FOUND
 import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_WORD_GUOCO_MIDTOWN_SQUARE
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import com.google.android.material.card.MaterialCardView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
 @UninstallModules(AppModule::class)
 @HiltAndroidTest
 class AfterSearchDirectionErrorExistsTest : BaseTestMainActivity() {
-
     private val uiDevice = UiDevice.getInstance(getInstrumentation())
 
     @Test
@@ -45,18 +46,23 @@ class AfterSearchDirectionErrorExistsTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(matches(isDisplayed()))
             edtSearch.perform(click())
-            onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_WORD_GUOCO_MIDTOWN_SQUARE))
-            BuildConfig.APPLICATION_ID
-            uiDevice.wait(
-                Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion")),
-                DELAY_20000
+            onView(withId(R.id.edt_search_places)).perform(
+                replaceText(
+                    TEST_WORD_GUOCO_MIDTOWN_SQUARE,
+                ),
             )
-            Thread.sleep(DELAY_2000)
+            BuildConfig.APPLICATION_ID
+            waitForView(
+                allOf(
+                    withId(R.id.rv_search_places_suggestion),
+                    isDisplayed(),
+                    hasMinimumChildCount(1),
+                ),
+            )
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
@@ -65,13 +71,13 @@ class AfterSearchDirectionErrorExistsTest : BaseTestMainActivity() {
                         onView(withId(R.id.rv_search_places_suggestion))?.perform(
                             RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
                                 0,
-                                click()
-                            )
+                                click(),
+                            ),
                         )
 
                         uiDevice.wait(
                             Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/tv_direction_time")),
-                            DELAY_5000
+                            DELAY_5000,
                         )
 
                         val btnDirection1 =
@@ -79,7 +85,10 @@ class AfterSearchDirectionErrorExistsTest : BaseTestMainActivity() {
                         if (btnDirection1.visibility == View.VISIBLE) {
                             val tvDirectionError2 =
                                 mActivityRule.activity.findViewById<AppCompatTextView>(R.id.tv_direction_error_2)
-                            Assert.assertTrue(TEST_FAILED_NO_DATA_FOUND, tvDirectionError2.visibility == View.VISIBLE)
+                            Assert.assertTrue(
+                                TEST_FAILED_NO_DATA_FOUND,
+                                tvDirectionError2.visibility == View.VISIBLE,
+                            )
                         }
                     } else {
                         Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
@@ -89,7 +98,7 @@ class AfterSearchDirectionErrorExistsTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(118, e)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }

--- a/app/src/androidTest/java/com/aws/amazonlocation/ui/main/bug/AfterSearchOutsideViewPortTest.kt
+++ b/app/src/androidTest/java/com/aws/amazonlocation/ui/main/bug/AfterSearchOutsideViewPortTest.kt
@@ -6,26 +6,27 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.aws.amazonlocation.AMAZON_MAP_READY
 import com.aws.amazonlocation.BaseTestMainActivity
-import com.aws.amazonlocation.BuildConfig
 import com.aws.amazonlocation.DELAY_15000
-import com.aws.amazonlocation.DELAY_2000
-import com.aws.amazonlocation.DELAY_20000
 import com.aws.amazonlocation.R
+import com.aws.amazonlocation.TEST_FAILED
 import com.aws.amazonlocation.TEST_FAILED_NO_DATA_FOUND
 import com.aws.amazonlocation.TEST_FAILED_NO_SEARCH_RESULT
 import com.aws.amazonlocation.TEST_WORD_KLUANG
 import com.aws.amazonlocation.di.AppModule
 import com.aws.amazonlocation.enableGPS
-import com.aws.amazonlocation.failTest
+import com.aws.amazonlocation.waitForView
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert
 import org.junit.Test
 
@@ -40,18 +41,13 @@ class AfterSearchOutsideViewPortTest : BaseTestMainActivity() {
         try {
             enableGPS(ApplicationProvider.getApplicationContext())
             uiDevice.wait(Until.hasObject(By.desc(AMAZON_MAP_READY)), DELAY_15000)
-            Thread.sleep(DELAY_2000)
 
             val edtSearch =
                 onView(withId(R.id.edt_search_places)).check(matches(isDisplayed()))
             edtSearch.perform(click())
             onView(withId(R.id.edt_search_places)).perform(replaceText(TEST_WORD_KLUANG))
-            BuildConfig.APPLICATION_ID
-            uiDevice.wait(
-                Until.hasObject(By.res("${BuildConfig.APPLICATION_ID}:id/rv_search_places_suggestion")),
-                DELAY_20000
-            )
-            Thread.sleep(DELAY_2000)
+
+            waitForView(allOf(withId(R.id.rv_search_places_suggestion), isDisplayed(), hasMinimumChildCount(1)))
             val rvSearchPlaceSuggestion =
                 mActivityRule.activity.findViewById<RecyclerView>(R.id.rv_search_places_suggestion)
             if (rvSearchPlaceSuggestion.adapter?.itemCount != null) {
@@ -62,7 +58,7 @@ class AfterSearchOutsideViewPortTest : BaseTestMainActivity() {
                 Assert.fail(TEST_FAILED_NO_SEARCH_RESULT)
             }
         } catch (e: Exception) {
-            failTest(118, e)
+            Assert.fail("$TEST_FAILED ${e.message}")
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As per the ask E2E test cases optimized and removed all unnecessary `Thread.sleep` calls. When there is a system-generated dialogue, we don't have access to it. In that case, `Thread.sleep` is needed. ex: Location permission.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

![suite_1](https://github.com/user-attachments/assets/c8368d4a-2000-472d-8dfb-f68b56348188)
![suite_2](https://github.com/user-attachments/assets/ebd87064-ed7e-4f3d-9ce7-ea40c577f903)
![suite_3](https://github.com/user-attachments/assets/d6e4694c-4677-4c13-80a2-491bd3b6daa8)
![suite_4](https://github.com/user-attachments/assets/0066ff2a-24f5-46b4-b59c-0ae5b3603326)
![suite_5](https://github.com/user-attachments/assets/66da44a4-8dae-47c2-a421-b6a3c6acfbd0)
