### PR TITLE
ALS-2049 Route time, political view name and version year fixes

### DIFF
--- a/app/src/main/java/com/aws/amazonlocation/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/aws/amazonlocation/ui/main/explore/ExploreFragment.kt
@@ -88,7 +88,6 @@ import com.aws.amazonlocation.utils.CLICK_TIME_DIFFERENCE
 import com.aws.amazonlocation.utils.DELAY_300
 import com.aws.amazonlocation.utils.DELAY_500
 import com.aws.amazonlocation.utils.DateFormat.HH_MM_AA
-import com.aws.amazonlocation.utils.DateFormat.HH_MM
 import com.aws.amazonlocation.utils.Debouncer
 import com.aws.amazonlocation.utils.Distance.DISTANCE_FOR_DRIVE_TRUCK
 import com.aws.amazonlocation.utils.Distance.DISTANCE_FOR_SCOOTER
@@ -1617,7 +1616,7 @@ class ExploreFragment :
                                     ?: legs.last().pedestrianLegDetails?.arrival?.time
                                     ?: legs.last().ferryLegDetails?.arrival?.time
                                 mViewModel.mNavigationResponse?.time =
-                                    getLastTime?.let { formatToDisplayTime(it, HH_MM) }
+                                    getLastTime?.let { formatToDisplayTime(it, HH_MM_AA) }
                                 for (leg in legs) {
                                     if (leg.vehicleLegDetails != null) {
                                         leg.vehicleLegDetails?.travelSteps?.forEach {

--- a/app/src/main/java/com/aws/amazonlocation/ui/main/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/aws/amazonlocation/ui/main/explore/ExploreViewModel.kt
@@ -25,7 +25,7 @@ import com.aws.amazonlocation.domain.`interface`.PlaceInterface
 import com.aws.amazonlocation.domain.`interface`.SearchDataInterface
 import com.aws.amazonlocation.domain.`interface`.SearchPlaceInterface
 import com.aws.amazonlocation.domain.usecase.LocationSearchUseCase
-import com.aws.amazonlocation.utils.DateFormat.HH_MM
+import com.aws.amazonlocation.utils.DateFormat.HH_MM_AA
 import com.aws.amazonlocation.utils.Units
 import com.aws.amazonlocation.utils.formatToDisplayTime
 import com.aws.amazonlocation.utils.getLanguageData
@@ -406,7 +406,7 @@ class ExploreViewModel
                     val getLastTime = legs.last().vehicleLegDetails?.arrival?.time
                         ?: legs.last().pedestrianLegDetails?.arrival?.time
                         ?: legs.last().ferryLegDetails?.arrival?.time
-                    mNavigationResponse?.time = getLastTime?.let { formatToDisplayTime(it, HH_MM) }
+                    mNavigationResponse?.time = getLastTime?.let { formatToDisplayTime(it, HH_MM_AA) }
                     for (leg in legs) {
                         if (leg.vehicleLegDetails != null) {
                             leg.vehicleLegDetails?.travelSteps?.forEach {

--- a/app/src/main/java/com/aws/amazonlocation/utils/Constants.kt
+++ b/app/src/main/java/com/aws/amazonlocation/utils/Constants.kt
@@ -257,7 +257,6 @@ object TrackerCons {
 object DateFormat {
     const val MMM_DD_YYYY = "MMM dd, yyyy"
     const val HH_MM_AA = "hh:mm aa"
-    const val HH_MM = "HH:mm"
     const val MM_DD_YYYY_HH_MM = "MM/dd/yyyy hh:mm aa"
     const val YYYY_MM_DD_T_HH_MM_SS = "yyyy-MM-dd'T'HH:mm:ssXXX"
 

--- a/app/src/main/java/com/aws/amazonlocation/utils/GeneralUtils.kt
+++ b/app/src/main/java/com/aws/amazonlocation/utils/GeneralUtils.kt
@@ -241,7 +241,7 @@ fun getPoliticalData(context: Context): ArrayList<PoliticalData> {
             countryCode = context.getString(R.string.flag_mar),
         ),
         PoliticalData(
-            countryName = context.getString(R.string.label_ps),
+            countryName = context.getString(R.string.label_pse),
             description = context.getString(R.string.description_ps),
             countryCode = context.getString(R.string.flag_ps),
         ),

--- a/app/src/main/res/values-ar/string.xml
+++ b/app/src/main/res/values-ar/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">تعلم المزيد</string>
   <string name="label_welcome_amazon">أهلا بك to\nAmazon الموقع نسخة تجريبية</string>
   <string name="label_continue">استمر</string>
-  <string name="label_right_aws">© 2024، Amazon الويب خدمات، شركة أو لها الشركات التابعة. جميع حقوق محجوز.</string>
+  <string name="label_right_aws">© 2025، Amazon الويب خدمات، شركة أو لها الشركات التابعة. جميع حقوق محجوز.</string>
   <string name="label_terms_desc">بواسطة تنزيل، تثبيت، أو باستخدام ال Amazon الموقع نسخة تجريبية التطبيق، أنت يوافق إلى ال التطبيقات **الشروط &amp; الشروط** من أجل استخدم.</string>
   <string name="label_terms_desc_terms_page">بواسطة تنزيل، تثبيت، أو باستخدام ال Amazon الموقع نسخة تجريبية التطبيق، أنت يوافق إلى ال التطبيقات **الشروط &amp; الشروط** من أجل استخدم.</string>
   <string name="label_version">الإصدار</string>

--- a/app/src/main/res/values-de/string.xml
+++ b/app/src/main/res/values-de/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">Lernen Mehr</string>
   <string name="label_welcome_amazon">Willkommen to\nAmazon Standort Demoversion</string>
   <string name="label_continue">Weiter</string>
-  <string name="label_right_aws">© 2024, Amazon Web Dienstleistungen, Inc. oder seine verbundene Unternehmen. Alles Rechte reserviert.</string>
+  <string name="label_right_aws">© 2025, Amazon Web Dienstleistungen, Inc. oder seine verbundene Unternehmen. Alles Rechte reserviert.</string>
   <string name="label_terms_desc">Von wird heruntergeladen, installieren, oder unter Verwendung von die Amazon Standort Demoversion App, Sie zustimmen zu die Apps\'s **Bedingungen &amp; Bedingungen** zum verwenden.</string>
   <string name="label_terms_desc_terms_page">Von wird heruntergeladen, installieren, oder unter Verwendung von die Amazon Standort Demoversion App, Sie zustimmen zu die Apps\'s **Bedingungen &amp; Bedingungen** zum verwenden.</string>
   <string name="label_version">Version</string>

--- a/app/src/main/res/values-es/string.xml
+++ b/app/src/main/res/values-es/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">Aprenda Más</string>
   <string name="label_welcome_amazon">Bienvenido to\nAmazon Ubicación Demo</string>
   <string name="label_continue">Continuar</string>
-  <string name="label_right_aws">© 2024, Amazon Web Servicios, Cía. o sus afiliados. Todos derechos reservado.</string>
+  <string name="label_right_aws">© 2025, Amazon Web Servicios, Cía. o sus afiliados. Todos derechos reservado.</string>
   <string name="label_terms_desc">Por descargando, instalar, o usando la Amazon Ubicación Demo Aplicación, tú acordar a la Apps\'s **Términos y Condiciones** por usar.</string>
   <string name="label_terms_desc_terms_page">Por descargando, instalar, o usando la Amazon Ubicación Demo Aplicación, tú acordar a la Apps\'s **Términos y Condiciones** por usar.</string>
   <string name="label_version">Versión</string>

--- a/app/src/main/res/values-fr/string.xml
+++ b/app/src/main/res/values-fr/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">Apprenez Plus</string>
   <string name="label_welcome_amazon">Bienvenue to\nAmazon Emplacement Démo</string>
   <string name="label_continue">Poursuivre</string>
-  <string name="label_right_aws">© 2024, Amazon Web Des services, Inc. ou ses affiliés. Tous droits réservé.</string>
+  <string name="label_right_aws">© 2025, Amazon Web Des services, Inc. ou ses affiliés. Tous droits réservé.</string>
   <string name="label_terms_desc">Par téléchargement, installation, ou en utilisant le Amazon Emplacement Démo Application, vous d\'accord pour le Applis **Termes et Conditions** pour utiliser.</string>
   <string name="label_terms_desc_terms_page">Par téléchargement, installation, ou en utilisant le Amazon Emplacement Démo Application, vous d\'accord pour le Applis **Termes et Conditions** pour utiliser.</string>
   <string name="label_version">Version</string>

--- a/app/src/main/res/values-hi/string.xml
+++ b/app/src/main/res/values-hi/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">सीखें ज़्यादा</string>
   <string name="label_welcome_amazon">वेलकम to\nAmazon लोकेशन डेमो</string>
   <string name="label_continue">जारी रखें</string>
-  <string name="label_right_aws">© 2024, Amazon वेब सेवाएँ, निगमित या इसके सहयोगी कंपनियों। सभी अधिकार आरक्षित।</string>
+  <string name="label_right_aws">© 2025, Amazon वेब सेवाएँ, निगमित या इसके सहयोगी कंपनियों। सभी अधिकार आरक्षित।</string>
   <string name="label_terms_desc">द्वारा डाउनलोड कर रहा है, स्थापित कर रहा है, या इस्तेमाल करते हुए यह Amazon लोकेशन डेमो ऐप, आप सहमत हैं को यह ऐप्लिकेशन\'s **शर्तें &amp; शर्तें** के लिए उपयोग करें।</string>
   <string name="label_terms_desc_terms_page">द्वारा डाउनलोड कर रहा है, स्थापित कर रहा है, या इस्तेमाल करते हुए यह Amazon लोकेशन डेमो ऐप, आप सहमत हैं को यह ऐप्लिकेशन\'s **शर्तें &amp; शर्तें** के लिए उपयोग करें।</string>
   <string name="label_version">वर्ज़न</string>

--- a/app/src/main/res/values-it/string.xml
+++ b/app/src/main/res/values-it/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">Impara Altro</string>
   <string name="label_welcome_amazon">Benvenuto to\nAmazon Posizione Dimostrazione</string>
   <string name="label_continue">Continua</string>
-  <string name="label_right_aws">© 2024, Amazon Web Servizi, Inc. o la sua affiliati. Tutti diritti riservato.</string>
+  <string name="label_right_aws">© 2025, Amazon Web Servizi, Inc. o la sua affiliati. Tutti diritti riservato.</string>
   <string name="label_terms_desc">Di scaricamento, installazione, o utilizzando lo Amazon Posizione Dimostrazione App, voi concordare a lo App **Termini &amp; Condizioni** per uso.</string>
   <string name="label_terms_desc_terms_page">Di scaricamento, installazione, o utilizzando lo Amazon Posizione Dimostrazione App, voi concordare a lo App **Termini &amp; Condizioni** per uso.</string>
   <string name="label_version">Versione</string>

--- a/app/src/main/res/values-iw/string.xml
+++ b/app/src/main/res/values-iw/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">ללמוד עוד</string>
   <string name="label_welcome_amazon">ברוכים הבאים to\nAmazon מיקום הדגמה</string>
   <string name="label_continue">המשך</string>
-  <string name="label_right_aws">© 2024, Amazon אינטרנט שירותים, "בע""מ" או שלו שותפים. כל זכויות שמורה.</string>
+  <string name="label_right_aws">© 2025, Amazon אינטרנט שירותים, "בע""מ" או שלו שותפים. כל זכויות שמורה.</string>
   <string name="label_terms_desc">על ידי הורדה, התקנה, או לנצל ה Amazon מיקום הדגמה אפליקציה, אתה מסכים כדי ה אפליקציות\ **תנאים &amp; תנאים** בשביל להשתמש.</string>
   <string name="label_terms_desc_terms_page">על ידי הורדה, התקנה, או לנצל ה Amazon מיקום הדגמה אפליקציה, אתה מסכים כדי ה אפליקציות\ **תנאים &amp; תנאים** בשביל להשתמש.</string>
   <string name="label_version">גרסה</string>

--- a/app/src/main/res/values-ja/string.xml
+++ b/app/src/main/res/values-ja/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">学ぶ もっと</string>
   <string name="label_welcome_amazon">ウェルカム to\nAmazon ロケーション デモ</string>
   <string name="label_continue">続行</string>
-  <string name="label_right_aws">© 2024, Amazon ウェブ サービス、 インコーポレイテッド または その アフィリエイト。 [すべて] 権利 予約済み。</string>
+  <string name="label_right_aws">© 2025, Amazon ウェブ サービス、 インコーポレイテッド または その アフィリエイト。 [すべて] 権利 予約済み。</string>
   <string name="label_terms_desc">によって ダウンロード中、 インストール、 または を使用します その Amazon ロケーション デモ アプリ、 あなた 同意する に その アプリ **規約 &amp; 条件** にとって 使用。</string>
   <string name="label_terms_desc_terms_page">によって ダウンロード中、 インストール、 または を使用します その Amazon ロケーション デモ アプリ、 あなた 同意する に その アプリ **規約 &amp; 条件** にとって 使用。</string>
   <string name="label_version">バージョン</string>

--- a/app/src/main/res/values-ko/string.xml
+++ b/app/src/main/res/values-ko/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">배우기 더 보기</string>
   <string name="label_welcome_amazon">어서 오십시오 to\nAmazon 위치 데모</string>
   <string name="label_continue">계속</string>
-  <string name="label_right_aws">© 2024, Amazon 웹 서비스, 주식회사 또는 그것의 계열사. 모두 권한 예약되어 있습니다.</string>
+  <string name="label_right_aws">© 2025, Amazon 웹 서비스, 주식회사 또는 그것의 계열사. 모두 권한 예약되어 있습니다.</string>
   <string name="label_terms_desc">에 의해 다운로드, 설치, 또는 를 사용하여 그 Amazon 위치 데모 앱, 당신 동의하다 에 그 앱\ \'의 **약관 &amp; 조건** ...에 대한 용도.</string>
   <string name="label_terms_desc_terms_page">에 의해 다운로드, 설치, 또는 를 사용하여 그 Amazon 위치 데모 앱, 당신 동의하다 에 그 앱\ \'의 **약관 &amp; 조건** ...에 대한 용도.</string>
   <string name="label_version">버전</string>

--- a/app/src/main/res/values-pt/string.xml
+++ b/app/src/main/res/values-pt/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">Aprenda Mais</string>
   <string name="label_welcome_amazon">Bem-vindo to\nAmazon Localização Demo</string>
   <string name="label_continue">Continuar</string>
-  <string name="label_right_aws">© 2024, Amazon Web Serviços, Inc. ou dela afiliados. Todos corretos reservado.</string>
+  <string name="label_right_aws">© 2025, Amazon Web Serviços, Inc. ou dela afiliados. Todos corretos reservado.</string>
   <string name="label_terms_desc">Por baixando, instalando, ou usando a Amazon Localização Demo Aplicativo, você aceita para a Aplicativos **Termos &amp; Condições** pelo usar.</string>
   <string name="label_terms_desc_terms_page">Por baixando, instalando, ou usando a Amazon Localização Demo Aplicativo, você aceita para a Aplicativos **Termos &amp; Condições** pelo usar.</string>
   <string name="label_version">Versão</string>

--- a/app/src/main/res/values-zh-rCN/string.xml
+++ b/app/src/main/res/values-zh-rCN/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">学习 更多</string>
   <string name="label_welcome_amazon">欢迎光临 to\nAmazon 地点 演示</string>
   <string name="label_continue">继续</string>
-  <string name="label_right_aws">© 2024年， Amazon 网页 服务， 公司 要么 它的 附属公司。 全部 权利 保留的。</string>
+  <string name="label_right_aws">© 2025年， Amazon 网页 服务， 公司 要么 它的 附属公司。 全部 权利 保留的。</string>
   <string name="label_terms_desc">由 正在下载， 正在安装， 要么 使用 这 Amazon 地点 演示 应用程序， 你 同意 到 这 应用程序 **条款 &amp; 条件** 为了 使用。</string>
   <string name="label_terms_desc_terms_page">由 正在下载， 正在安装， 要么 使用 这 Amazon 地点 演示 应用程序， 你 同意 到 这 应用程序 **条款 &amp; 条件** 为了 使用。</string>
   <string name="label_version">版本</string>

--- a/app/src/main/res/values-zh-rTW/string.xml
+++ b/app/src/main/res/values-zh-rTW/string.xml
@@ -146,7 +146,7 @@
   <string name="btn_learn_more">學習 更多</string>
   <string name="label_welcome_amazon">歡迎 to\nAmazon 位置 演示</string>
   <string name="label_continue">繼續</string>
-  <string name="label_right_aws">© 2024, Amazon 網頁 服務， 公司 或者 它的 附屬機構。 所有 權利 保留。</string>
+  <string name="label_right_aws">© 2025, Amazon 網頁 服務， 公司 或者 它的 附屬機構。 所有 權利 保留。</string>
   <string name="label_terms_desc">通過 下載， 安裝， 或者 運用 該 Amazon 位置 演示 應用程序， 您 同意 至 該 應用\ 的 ** 條款 &amp; 條件 ** 為了 使用。</string>
   <string name="label_terms_desc_terms_page">通過 下載， 安裝， 或者 運用 該 Amazon 位置 演示 應用程序， 您 同意 至 該 應用\ 的 ** 條款 &amp; 條件 ** 為了 使用。</string>
   <string name="label_version">版本</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,7 +164,7 @@
     <string name="btn_learn_more">Learn More</string>
     <string name="label_welcome_amazon">Welcome to\nAmazon Location Demo</string>
     <string name="label_continue">Continue</string>
-    <string name="label_right_aws">© 2024, Amazon Web Services, Inc. or its affiliates. All rights reserved.</string>
+    <string name="label_right_aws">© 2025, Amazon Web Services, Inc. or its affiliates. All rights reserved.</string>
     <string name="label_terms_desc">By downloading, installing, or using the Amazon Location Demo App, you agree to the App\'s **Terms &amp; Conditions** for use.</string>
     <string name="label_terms_desc_terms_page">By downloading, installing, or using the Amazon Location Demo App, you agree to the App\'s **Terms &amp; Conditions** for use.</string>
     <string name="label_version">Version</string>
@@ -295,7 +295,7 @@
     <string name="label_ury" translatable="false">URY</string>
     <string name="label_geo" translatable="false">GEO</string>
     <string name="label_cyp" translatable="false">CYP</string>
-    <string name="label_ps" translatable="false">PS</string>
+    <string name="label_pse" translatable="false">PSE</string>
     <string name="label_grc" translatable="false">GRC</string>
 
     <string name="label_map_language">Map language</string>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix: arrival time changed to 12-hour format, Palestine's represented with abbreviation changed to PSE from PS, version year updated with 2025
<p>
    <img src="https://github.com/user-attachments/assets/33015dbe-ba1d-42ef-b48b-f49f8e8d671b" alt="Navigation Time" width="200">
    <img src="https://github.com/user-attachments/assets/f7beadeb-8096-4982-a816-29c530fea076" alt="PSE" width="200">
    <img src="https://github.com/user-attachments/assets/4c68181d-8dc3-4fc5-8278-660111b8763c" alt="Version Year" width="200">
</p>




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
