### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/scripts/translation-script/translate.js
+++ b/scripts/translation-script/translate.js
@@ -75,10 +75,9 @@ const main = async() => {
 
                                 // Add a backslash before the ' sign if not already present
                                 if (!translatedWordWithTags.includes("\\'")) {
-                                    translatedWordWithTags = translatedWordWithTags.replace(
-                                        /'/g,
-                                        "\\'"
-                                    );
+                                    translatedWordWithTags = translatedWordWithTags
+                                        .replace(/\\/g, "\\\\")
+                                        .replace(/'/g, "\\'");
                                 }
 
                                 translatedWords.push(translatedWordWithTags);


### PR DESCRIPTION
Potential fix for [https://github.com/aws-geospatial/amazon-location-features-demo-android/security/code-scanning/8](https://github.com/aws-geospatial/amazon-location-features-demo-android/security/code-scanning/8)

In general, whenever escaping is needed (such as escaping single quotes for embedding strings), all existing backslashes must be escaped first, *then* escaping of other characters such as single quotes should follow. This avoids cases where pre-existing escapes could be broken or lead to confusion.

Specifically, in line 78, before replacing `'` with `\\'`, we should replace every backslash (`\`) with double-backslash (`\\`) globally (using `/\\/g`). Then, in the result of that operation, replace every single-quote with `\\'` globally. This ensures that both backslashes and single quotes are uniformly and safely escaped.

We need to update the replacement block for line 78 accordingly, chaining the replacements so that all backslashes are escaped before escaping single quotes. No additional imports are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
