### PR TITLE
fix: resolve CVE-2026-41907 uuid buffer bounds check vulnerability

### DIFF
--- a/scripts/translation-script/package-lock.json
+++ b/scripts/translation-script/package-lock.json
@@ -2206,9 +2206,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"


### PR DESCRIPTION
Resolves Dependabot alert #47 (CVE-2026-41907): uuid missing buffer bounds check in v3/v5/v6 when buf is provided.

Applied `npm audit fix` in `scripts/translation-script/` — only `package-lock.json` changed.